### PR TITLE
Fix calling Un/Partitioned() multiple times in EventHandlerBuilder 

### DIFF
--- a/Samples/Advanced/MyOtherEvent.cs
+++ b/Samples/Advanced/MyOtherEvent.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.SDK.Events;
+
+namespace Basic
+{
+    [EventType("2fc3df44-0ee6-41d7-b0eb-eb2b841894df")]
+    class MyOtherEvent
+    {
+        public MyOtherEvent(string aString, int anInteger)
+        {
+            AString = aString;
+            AnInteger = anInteger;
+        }
+        public string AString { get; }
+        public int AnInteger { get; }
+    }
+}

--- a/Samples/Advanced/Program.cs
+++ b/Samples/Advanced/Program.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Dolittle.SDK;
-using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Events.Filters;
@@ -17,8 +16,10 @@ namespace Basic
             Console.WriteLine("Hello World!");
             var client = Client.ForMicroservice("7a6155dd-9109-4488-8f6f-c57fe4b65bfb")
                 .WithEventTypes(eventTypes =>
-                    eventTypes
-                        .Register<MyEvent>())
+                {
+                    eventTypes.Register<MyEvent>();
+                    eventTypes.Register<MyOtherEvent>();
+                })
                 .WithFilters(filtersBuilder =>
                     filtersBuilder
                         .CreatePublicFilter("2c087657-b318-40b1-ae92-a400de44e507", filterBuilder =>
@@ -28,13 +29,22 @@ namespace Basic
                                 return Task.FromResult(new PartitionedFilterResult(true, PartitionId.Unspecified));
                             })))
                 .WithEventHandlers(eventHandlersBuilder =>
-                    eventHandlersBuilder
-                        .RegisterEventHandler<MyEventHandler>())
+                {
+                    eventHandlersBuilder.RegisterEventHandler<MyEventHandler>();
+                    
+                    eventHandlersBuilder.CreateEventHandler("44ac0f75-9f13-45f1-b3b1-3f222f92ca57")
+                        .Partitioned()
+                        .Handle<MyEvent>((@event, ctx) => Console.WriteLine("A second handle method for MyEvent."))
+                        .Handle<MyOtherEvent>((@event, ctx) => Console.WriteLine("A handle method for MyOtherevent."));
+                })
                 .Build();
 
             var myEvent = new MyEvent("test string", 12345);
             var commit = client.EventStore.ForTenant("900893e7-c4cc-4873-8032-884e965e4b97").CommitPublic(myEvent, "8ac5b16a-0b88-4578-a005-e5247c611777");
             Console.WriteLine(commit.Result.Events);
+            var myOtherEvent = new MyOtherEvent("other test stering", 54321);
+            var otherCommit = client.EventStore.ForTenant("900893e7-c4cc-4873-8032-884e965e4b97").CommitPublic(myOtherEvent, "8ac5b16a-0b88-4578-a005-e5247c611777");
+            Console.WriteLine(otherCommit.Result.Events);
 
             client.Wait();
         }

--- a/Source/Events.Handling/Builder/EventHandlersBuilder.cs
+++ b/Source/Events.Handling/Builder/EventHandlersBuilder.cs
@@ -21,14 +21,12 @@ namespace Dolittle.SDK.Events.Handling.Builder
         /// Start building an event handler.
         /// </summary>
         /// <param name="eventHandlerId">The <see cref="EventHandlerId" />.</param>
-        /// <param name="callback">Callback for building the event handler.</param>
         /// <returns>The <see cref="EventHandlersBuilder" /> for continuation.</returns>
-        public EventHandlersBuilder CreateEventHandler(EventHandlerId eventHandlerId, Action<EventHandlerBuilder> callback)
+        public EventHandlerBuilder CreateEventHandler(EventHandlerId eventHandlerId)
         {
             var builder = new EventHandlerBuilder(eventHandlerId);
-            callback(builder);
             _builders.Add(builder);
-            return this;
+            return builder;
         }
 
         /// <summary>


### PR DESCRIPTION
It was possible to write client building code like:
```csharp
_.CreateEventHandle("some-guid", builder =>
{
    // on the inside, calling Partitioned() sets builder._methodsBuilder = new EventHandlerMethodsBuilder()
    builder.Partitioned()
        // this will never be called
        .Handle<MyEvent>((@event, ctx));
    // Partitioned() once again does builder._methodsBuilder = new EventHandlerMethodsBuilder()
    // this removes all of the old handle methods
    builder.Partitioned();
        .Handle<MyOtherEvent>((@event, ctx));
})
```
and as you we're working with the callback it wasn't obvious that this was a trap.

This fixes this by providing a callbackless API:
```csharp
eventHandlersBuilder.CreateEventHandler("44ac0f75-9f13-45f1-b3b1-3f222f92ca57")
    .Partitioned()
    .Handle<MyEvent>((@event, ctx) => Console.WriteLine("A second handle method for MyEvent."))
    .Handle<MyOtherEvent>((@event, ctx) => Console.WriteLine("A handle method for MyOtherevent."));

```