### PR TITLE
Put EventType of committed event in EventContext

### DIFF
--- a/Source/Events/EventContext.cs
+++ b/Source/Events/EventContext.cs
@@ -17,18 +17,21 @@ namespace Dolittle.SDK.Events
         /// Initializes a new instance of the <see cref="EventContext"/> class.
         /// </summary>
         /// <param name="sequenceNumber">The <see cref="EventLogSequenceNumber">sequence number</see> that uniquely identifies the event in the event log which it was committed.</param>
+        /// <param name="eventType">The <see cref="EventType"/> of the event.</param>
         /// <param name="eventSourceId">The <see cref="EventSourceId"/> that the event was committed to.</param>
         /// <param name="occurred">The <see cref="DateTimeOffset"/> when the event was committed to the <see cref="IEventStore"/>.</param>
         /// <param name="committedExecutionContext">The <see cref="ExecutionContext"/> in which the event was committed to the <see cref="IEventStore"/>.</param>
         /// <param name="currentExecutionContext">The <see cref="ExecutionContext"/> in which the event is currently being processed.</param>
         public EventContext(
             EventLogSequenceNumber sequenceNumber,
+            EventType eventType,
             EventSourceId eventSourceId,
             DateTimeOffset occurred,
             ExecutionContext committedExecutionContext,
             ExecutionContext currentExecutionContext)
         {
             SequenceNumber = sequenceNumber;
+            Type = eventType;
             EventSourceId = eventSourceId;
             Occurred = occurred;
             CommittedExecutionContext = committedExecutionContext;
@@ -39,6 +42,11 @@ namespace Dolittle.SDK.Events
         /// Gets the <see cref="EventLogSequenceNumber">sequence number</see> that uniquely identifies the event in the event log which it was committed.
         /// </summary>
         public EventLogSequenceNumber SequenceNumber { get; }
+
+        /// <summary>
+        /// Gets the <see cref="EventType" /> of the event.
+        /// </summary>
+        public EventType Type { get; }
 
         /// <summary>
         /// Gets the <see cref="EventSourceId"/> that the event was committed to.

--- a/Source/Events/Store/CommittedEventExtensions.cs
+++ b/Source/Events/Store/CommittedEventExtensions.cs
@@ -19,6 +19,7 @@ namespace Dolittle.SDK.Events.Store
         public static EventContext GetEventContext(this CommittedEvent @event, ExecutionContext currentExecutionContext)
             => new EventContext(
                 @event.EventLogSequenceNumber,
+                @event.EventType,
                 @event.EventSource,
                 @event.Occurred,
                 @event.ExecutionContext,

--- a/Specifications/Events.Handling/Internal/for_EventHandlerProcessor/when_handling/a_request_to_handle_event/and_handler_does_not_fail.cs
+++ b/Specifications/Events.Handling/Internal/for_EventHandlerProcessor/when_handling/a_request_to_handle_event/and_handler_does_not_fail.cs
@@ -34,6 +34,7 @@ namespace Dolittle.SDK.Events.Handling.Internal.for_EventHandlerProcessor.when_h
                 .Returns(stream_event);
             event_context = new EventContext(
                 committed_event.EventLogSequenceNumber,
+                committed_event.Type.To<EventType, EventTypeId>(),
                 committed_event.EventSourceId.To<EventSourceId>(),
                 committed_event.Occurred.ToDateTimeOffset(),
                 execution_context,

--- a/Specifications/Events.Handling/Internal/for_EventHandlerProcessor/when_handling/a_request_to_handle_event/and_handler_fails.cs
+++ b/Specifications/Events.Handling/Internal/for_EventHandlerProcessor/when_handling/a_request_to_handle_event/and_handler_fails.cs
@@ -33,6 +33,7 @@ namespace Dolittle.SDK.Events.Handling.Internal.for_EventHandlerProcessor.when_h
                 .Returns(stream_event);
             event_context = new EventContext(
                 committed_event.EventLogSequenceNumber,
+                committed_event.Type.To<EventType, EventTypeId>(),
                 committed_event.EventSourceId.To<EventSourceId>(),
                 committed_event.Occurred.ToDateTimeOffset(),
                 execution_context,

--- a/Specifications/Events.Handling/for_EventHandler/when_handling/given/all_dependencies.cs
+++ b/Specifications/Events.Handling/for_EventHandler/when_handling/given/all_dependencies.cs
@@ -16,6 +16,7 @@ namespace Dolittle.SDK.Events.Handling.for_EventHandler.when_handling.given
         {
             event_context = new EventContext(
                 3,
+                new EventType("8b9d6262-0e37-4f87-934a-1d6bccf8fc55"),
                 "7d387632-68d8-4187-aa8a-b7d191a1b130",
                 DateTimeOffset.UtcNow,
                 new Execution.ExecutionContext(


### PR DESCRIPTION
## Summary

Adds the EventType property to the EventContext class that's used In event handlers and filters. I think that the EventType of the event to be handled should be easily accessible. I think it fits well inside the context of the event, EventContext. Since we can commit events in a raw format (with no association between Type and EventType) we need to have the ability to know the EventType of the event you are handing in a filter or event handler

### Added

- EventType Type read-only property on EventContext
