### PR TITLE
Move tcs

### DIFF
--- a/Source/Services/MethodCaller.cs
+++ b/Source/Services/MethodCaller.cs
@@ -71,8 +71,8 @@ namespace Dolittle.SDK.Services
                     _ => { },
                     error =>
                     {
-                        observer.OnError(error);
                         tcs.Cancel();
+                        observer.OnError(error);
                     });
 
         async Task ReceiveAllMessagesFromServer<T>(IObserver<T> observer, IAsyncStreamReader<T> reader, CancellationToken token)

--- a/Source/Services/ReverseCallClient.cs
+++ b/Source/Services/ReverseCallClient.cs
@@ -89,9 +89,9 @@ namespace Dolittle.SDK.Services
         /// <inheritdoc/>
         public IDisposable Subscribe(IObserver<TConnectResponse> observer)
         {
-            #pragma warning disable CA2000
+#pragma warning disable CA2000
             var toClientMessages = new Subject<TServerMessage>();
-            #pragma warning restore CA2000
+#pragma warning restore CA2000
 
             var connectResponse = GetConnectResponseFromFirstMessageOrError(toClientMessages);
             var timeout = TimeoutAfterPingIntervalAfterFirstMessageIsReceived(toClientMessages);
@@ -103,10 +103,6 @@ namespace Dolittle.SDK.Services
 
             var connectResponseAndErrors = MergeConnectResponseWithErrorsFromServer(connectResponse, toClientMessages);
             connectResponseAndErrors.Subscribe(observer);
-
-            toClientMessages
-                .Where(MessageIsPing)
-                .Subscribe(_ => Thread.Sleep(20));
 
             var subscription = _caller.Call(_protocol, toServerMessages, _cancellationToken).Subscribe(toClientMessages);
 
@@ -216,7 +212,7 @@ namespace Dolittle.SDK.Services
 
             var response = await Handler.Handle(request, executionContext, token).ConfigureAwait(false);
 
-            var responseContext = new ReverseCallResponseContext { CallId = requestContext.CallId };
+            var responseContext = new ReverseCallResponseContext { CallId = requestContext.CallId };
             _protocol.SetResponseContextIn(responseContext, response);
 
             return response;
@@ -224,10 +220,10 @@ namespace Dolittle.SDK.Services
 
         ReverseCallArgumentsContext CreateReverseCallArgumentsContext()
             => new ReverseCallArgumentsContext
-                {
-                    HeadId = Guid.NewGuid().ToProtobuf(),
-                    ExecutionContext = _executionContext.ToProtobuf(),
-                    PingInterval = Duration.FromTimeSpan(_pingInterval),
-                };
+            {
+                HeadId = Guid.NewGuid().ToProtobuf(),
+                ExecutionContext = _executionContext.ToProtobuf(),
+                PingInterval = Duration.FromTimeSpan(_pingInterval),
+            };
     }
 }

--- a/Specifications/Services/for_ReverseCallClient/when_connected/and_server_does_not_send_a_ping_before_the_deadline.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_connected/and_server_does_not_send_a_ping_before_the_deadline.cs
@@ -8,7 +8,6 @@ using Microsoft.Reactive.Testing;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_connected
 {
-    [Ignore("because thread needs to sleep")]
     public class and_server_does_not_send_a_ping_before_the_deadline : given.a_reverse_call_client
     {
         static ConnectArguments arguments;
@@ -23,7 +22,7 @@ namespace Dolittle.SDK.Services.for_ReverseCallClient.when_connected
             response = new ConnectResponse(arguments);
 
             serverToClientMessages = scheduler.CreateHotObservable(
-                OnNext(100, new ServerMessage { Response = response }),
+                OnNext(100, new ServerMessage { Response = response }),
                 OnCompleted<ServerMessage>(500));
         };
 

--- a/Specifications/Services/for_ReverseCallClient/when_connected/and_server_sends_a_ping.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_connected/and_server_sends_a_ping.cs
@@ -9,7 +9,6 @@ using Microsoft.Reactive.Testing;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_connected
 {
-    [Ignore("because thread needs to sleep")]
     public class and_server_sends_a_ping : given.a_reverse_call_client
     {
         static ConnectArguments arguments;
@@ -24,7 +23,7 @@ namespace Dolittle.SDK.Services.for_ReverseCallClient.when_connected
             response = new ConnectResponse(arguments);
 
             serverToClientMessages = scheduler.CreateHotObservable(
-                OnNext(100, new ServerMessage { Response = response }),
+                OnNext(100, new ServerMessage { Response = response }),
                 OnNext(110, new ServerMessage { Ping = new Ping() }),
                 OnCompleted<ServerMessage>(120));
 

--- a/Specifications/Services/for_ReverseCallClient/when_connected/and_server_sends_two_pings_before_deadline_and_one_ping_after.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_connected/and_server_sends_two_pings_before_deadline_and_one_ping_after.cs
@@ -9,7 +9,6 @@ using Microsoft.Reactive.Testing;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_connected
 {
-    [Ignore("because thread needs to sleep")]
     public class and_server_sends_two_pings_before_deadline_and_one_ping_after : given.a_reverse_call_client
     {
         static ConnectArguments arguments;
@@ -24,7 +23,7 @@ namespace Dolittle.SDK.Services.for_ReverseCallClient.when_connected
             response = new ConnectResponse(arguments);
 
             serverToClientMessages = scheduler.CreateHotObservable(
-                OnNext(100, new ServerMessage { Response = response }),
+                OnNext(100, new ServerMessage { Response = response }),
                 OnNext(110, new ServerMessage { Ping = new Ping() }),
                 OnNext(130, new ServerMessage { Ping = new Ping() }),
                 OnNext(170, new ServerMessage { Ping = new Ping() }),

--- a/Specifications/Services/for_ReverseCallClient/when_handling/a_request_that_completes_successfully.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_handling/a_request_that_completes_successfully.cs
@@ -18,7 +18,6 @@ using Version = Dolittle.SDK.Microservices.Version;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_handling
 {
-    [Ignore("because thread needs to sleep")]
     public class a_request_that_completes_successfully : given.a_reverse_call_client
     {
         static ConnectArguments connectArguments;
@@ -66,7 +65,7 @@ namespace Dolittle.SDK.Services.for_ReverseCallClient.when_handling
                 .Returns(Task.FromResult(response));
 
             serverToClientMessages = scheduler.CreateHotObservable(
-                OnNext(100, new ServerMessage { Response = connectResponse }),
+                OnNext(100, new ServerMessage { Response = connectResponse }),
                 OnNext(110, new ServerMessage { Request = request }),
                 OnCompleted<ServerMessage>(120));
         };

--- a/Specifications/Services/for_ReverseCallClient/when_handling/a_request_that_takes_a_long_time_to_complete.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_handling/a_request_that_takes_a_long_time_to_complete.cs
@@ -18,7 +18,6 @@ using Version = Dolittle.SDK.Microservices.Version;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_handling
 {
-    [Ignore("because thread needs to sleep")]
     public class a_request_that_takes_a_long_time_to_complete : given.a_reverse_call_client
     {
         static ConnectArguments connectArguments;
@@ -70,7 +69,7 @@ namespace Dolittle.SDK.Services.for_ReverseCallClient.when_handling
                 .Returns(slowResponse);
 
             serverToClientMessages = scheduler.CreateHotObservable(
-                OnNext(100, new ServerMessage { Response = connectResponse }),
+                OnNext(100, new ServerMessage { Response = connectResponse }),
                 OnNext(110, new ServerMessage { Request = request }),
                 OnNext(140, new ServerMessage { Ping = new Ping() }),
                 OnNext(180, new ServerMessage { Ping = new Ping() }),

--- a/Specifications/Services/for_ReverseCallClient/when_handling/a_request_that_throws_an_error.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_handling/a_request_that_throws_an_error.cs
@@ -18,7 +18,6 @@ using Version = Dolittle.SDK.Microservices.Version;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_handling
 {
-    [Ignore("because thread needs to sleep")]
     public class a_request_that_throws_an_error : given.a_reverse_call_client
     {
         static ConnectArguments connectArguments;
@@ -67,7 +66,7 @@ namespace Dolittle.SDK.Services.for_ReverseCallClient.when_handling
                 .Returns(Task.FromException<Response>(exception));
 
             serverToClientMessages = scheduler.CreateHotObservable(
-                OnNext(100, new ServerMessage { Response = connectResponse }),
+                OnNext(100, new ServerMessage { Response = connectResponse }),
                 OnNext(110, new ServerMessage { Request = request }),
                 OnCompleted<ServerMessage>(120));
         };

--- a/Specifications/Services/for_ReverseCallClient/when_handling/two_requests_at_the_same_time.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_handling/two_requests_at_the_same_time.cs
@@ -18,7 +18,6 @@ using Version = Dolittle.SDK.Microservices.Version;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_handling
 {
-    [Ignore("because thread needs to sleep")]
     public class two_requests_at_the_same_time : given.a_reverse_call_client
     {
         static ConnectArguments connectArguments;
@@ -104,7 +103,7 @@ namespace Dolittle.SDK.Services.for_ReverseCallClient.when_handling
                 .Returns(secondSlowResponse);
 
             serverToClientMessages = scheduler.CreateHotObservable(
-                OnNext(100, new ServerMessage { Response = connectResponse }),
+                OnNext(100, new ServerMessage { Response = connectResponse }),
                 OnNext(110, new ServerMessage { Request = firstRequest }),
                 OnNext(120, new ServerMessage { Request = secondRequest }),
                 OnCompleted<ServerMessage>(250));

--- a/Specifications/Services/for_ReverseCallClient/when_subscribing/and_server_closes_connection_without_sending_any_messages.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_subscribing/and_server_closes_connection_without_sending_any_messages.cs
@@ -7,7 +7,6 @@ using Microsoft.Reactive.Testing;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_subscribing
 {
-    [Ignore("because thread needs to sleep")]
     public class and_server_closes_connection_without_sending_any_messages : given.a_reverse_call_client
     {
         static ConnectArguments arguments;

--- a/Specifications/Services/for_ReverseCallClient/when_subscribing/and_server_does_not_reply_with_connect_reponse_as_first_message.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_subscribing/and_server_does_not_reply_with_connect_reponse_as_first_message.cs
@@ -7,7 +7,6 @@ using Microsoft.Reactive.Testing;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_subscribing
 {
-    [Ignore("because thread needs to sleep")]
     public class and_server_does_not_reply_with_connect_reponse_as_first_message : given.a_reverse_call_client
     {
         static ConnectArguments arguments;
@@ -20,7 +19,7 @@ namespace Dolittle.SDK.Services.for_ReverseCallClient.when_subscribing
             arguments = new ConnectArguments();
 
             serverToClientMessages = scheduler.CreateHotObservable(
-                OnNext(200, new ServerMessage { Request = new Request() }));
+                OnNext(200, new ServerMessage { Request = new Request() }));
 
             client = reverse_call_client_with(arguments, serverToClientMessages);
         };

--- a/Specifications/Services/for_ReverseCallClient/when_subscribing/and_server_replies_with_connect_response_as_first_message.cs
+++ b/Specifications/Services/for_ReverseCallClient/when_subscribing/and_server_replies_with_connect_response_as_first_message.cs
@@ -8,7 +8,6 @@ using Microsoft.Reactive.Testing;
 
 namespace Dolittle.SDK.Services.for_ReverseCallClient.when_subscribing
 {
-    [Ignore("because thread needs to sleep")]
     public class and_server_replies_with_connect_response_as_first_message : given.a_reverse_call_client
     {
         static ConnectArguments arguments;
@@ -23,7 +22,7 @@ namespace Dolittle.SDK.Services.for_ReverseCallClient.when_subscribing
             response = new ConnectResponse(arguments);
 
             serverToClientMessages = scheduler.CreateHotObservable(
-                OnNext(100, new ServerMessage { Response = response }),
+                OnNext(100, new ServerMessage { Response = response }),
                 OnCompleted<ServerMessage>(200));
 
             client = reverse_call_client_with(arguments, serverToClientMessages);


### PR DESCRIPTION
## Summary

Potentially fixes a problem with reverse calls

### Fixed

- Switch the place on a cancellation token source cancellation and Observable.OnError()

### Removed

- Sleep on messages from server
