### PR TITLE
Allow pings while waiting for a registration response

### DIFF
--- a/Source/Events.Processing/EventProcessors.cs
+++ b/Source/Events.Processing/EventProcessors.cs
@@ -83,12 +83,12 @@ namespace Dolittle.SDK.Events.Processing
                     var connectFailure = protocol.GetFailureFromConnectResponse(client.ConnectResponse);
                     if (connectFailure != null)
                     {
-                        _logger.LogWarning("{Kind} {Identifier} received a failure from the Runtime, retrying in 1s. {FailureReason}", eventProcessor.Kind, eventProcessor.Identifier, connectFailure.Reason);
+                        _logger.LogWarning("{Kind} {Identifier} received a failure from the Runtime, retrying in 1s {FailureReason}", eventProcessor.Kind, eventProcessor.Identifier, connectFailure.Reason);
                         await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
                         continue;
                     }
 
-                    _logger.LogDebug("{Kind} {Identifier} registered with the Runtime, start handling requests.", eventProcessor.Kind, eventProcessor.Identifier);
+                    _logger.LogDebug("{Kind} {Identifier} registered with the Runtime, start handling requests", eventProcessor.Kind, eventProcessor.Identifier);
                     await client.Handle(eventProcessor, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception exception)

--- a/Source/Events.Processing/EventProcessors.cs
+++ b/Source/Events.Processing/EventProcessors.cs
@@ -75,7 +75,7 @@ namespace Dolittle.SDK.Events.Processing
                     var connected = await client.Connect(eventProcessor.RegistrationRequest, cancellationToken).ConfigureAwait(false);
                     if (!connected)
                     {
-                        _logger.LogWarning("{Kind} {Identifier} failed to connect to the Runtime, retrying in 1s", eventProcessor.Kind, eventProcessor.Identifier);
+                        _logger.LogWarning("{Kind} {Identifier} failed to connect to the Runtime, retrying in 1s.", eventProcessor.Kind, eventProcessor.Identifier);
                         await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
                         continue;
                     }
@@ -83,7 +83,7 @@ namespace Dolittle.SDK.Events.Processing
                     var connectFailure = protocol.GetFailureFromConnectResponse(client.ConnectResponse);
                     if (connectFailure != null)
                     {
-                        _logger.LogWarning("{Kind} {Identifier} received a failure from the Runtime, retrying in 1s {FailureReason}", eventProcessor.Kind, eventProcessor.Identifier, connectFailure.Reason);
+                        _logger.LogWarning("{Kind} {Identifier} received a failure from the Runtime, retrying in 1s. {FailureReason}", eventProcessor.Kind, eventProcessor.Identifier, connectFailure.Reason);
                         await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
                         continue;
                     }


### PR DESCRIPTION
- Allows pings to be received before the connection response.
- If any messages are received over the stream during the connect call, "refresh" the tokens `CancelAfter`. This could be set to only refresh during pings too, but I think the points is to just know that the stream is overall alive.
