### PR TITLE
Adding support for setting default JsonSerializerSettings

### DIFF
--- a/Source/Events/Store/Converters/EventContentSerializer.cs
+++ b/Source/Events/Store/Converters/EventContentSerializer.cs
@@ -19,7 +19,7 @@ namespace Dolittle.SDK.Events.Store.Converters
         /// </summary>
         /// <param name="eventTypes"><see cref="IEventTypes"/> for mapping types and artifacts.</param>
         /// <param name="jsonSerializerSettingsProvider"><see cref="Func{T}"/> that provides <see cref="JsonSerializerSettings"/>.</param>
-        public EventContentSerializer(IEventTypes eventTypes, Func<JsonSerializerSettings> jsonSerializerSettingsProvider = null)
+        public EventContentSerializer(IEventTypes eventTypes, Func<JsonSerializerSettings> jsonSerializerSettingsProvider)
         {
             _eventTypes = eventTypes;
             _jsonSerializerSettingsProvider = jsonSerializerSettingsProvider;

--- a/Source/Events/Store/Converters/EventContentSerializer.cs
+++ b/Source/Events/Store/Converters/EventContentSerializer.cs
@@ -23,7 +23,6 @@ namespace Dolittle.SDK.Events.Store.Converters
         {
             _eventTypes = eventTypes;
             _jsonSerializerSettingsProvider = jsonSerializerSettingsProvider;
-            _jsonSerializerSettingsProvider ??= () => new JsonSerializerSettings();
         }
 
         /// <inheritdoc/>

--- a/Source/SDK/ClientBuilder.cs
+++ b/Source/SDK/ClientBuilder.cs
@@ -241,11 +241,11 @@ namespace Dolittle.SDK
         }
 
         /// <summary>
-        /// Sets the default <see cref="JsonSerializerSettings"/> .
+        /// Sets the <see cref="JsonSerializerSettings"/> for serializing events.
         /// </summary>
         /// <param name="jsonSerializerSettings">The default <see cref="JsonSerializerSettings"/>.</param>
         /// <returns>The client builder for continuation.</returns>
-        public ClientBuilder WithJsonSerializerSettings(JsonSerializerSettings jsonSerializerSettings)
+        public ClientBuilder WithEventSerializerSettings(JsonSerializerSettings jsonSerializerSettings)
         {
             _jsonSerializerSettings = jsonSerializerSettings;
             return this;

--- a/Source/SDK/ClientBuilder.cs
+++ b/Source/SDK/ClientBuilder.cs
@@ -27,6 +27,7 @@ using Dolittle.SDK.Security;
 using Dolittle.SDK.Services;
 using Dolittle.SDK.Tenancy;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Environment = Dolittle.SDK.Microservices.Environment;
 using ExecutionContext = Dolittle.SDK.Execution.ExecutionContext;
 using Version = Dolittle.SDK.Microservices.Version;
@@ -55,6 +56,7 @@ namespace Dolittle.SDK
         CancellationToken _cancellation;
         RetryPolicy _retryPolicy;
         EventSubscriptionRetryPolicy _eventHorizonRetryPolicy;
+        JsonSerializerSettings _jsonSerializerSettings;
 
         ILoggerFactory _loggerFactory = LoggerFactory.Create(_ =>
             {
@@ -239,6 +241,17 @@ namespace Dolittle.SDK
         }
 
         /// <summary>
+        /// Sets the default <see cref="JsonSerializerSettings"/> .
+        /// </summary>
+        /// <param name="jsonSerializerSettings">The default <see cref="JsonSerializerSettings"/>.</param>
+        /// <returns>The client builder for continuation.</returns>
+        public ClientBuilder WithJsonSerializerSettings(JsonSerializerSettings jsonSerializerSettings)
+        {
+            _jsonSerializerSettings = jsonSerializerSettings;
+            return this;
+        }
+
+        /// <summary>
         /// Build the Client.
         /// </summary>
         /// <returns>The <see cref="Client"/>.</returns>
@@ -262,7 +275,7 @@ namespace Dolittle.SDK
                 executionContext,
                 _loggerFactory);
 
-            var serializer = new EventContentSerializer(eventTypes);
+            var serializer = new EventContentSerializer(eventTypes, _jsonSerializerSettings);
             var eventToProtobufConverter = new EventToProtobufConverter(serializer);
             var eventToSDKConverter = new EventToSDKConverter(serializer);
             var aggregateEventToProtobufConverter = new AggregateEventToProtobufConverter(serializer);

--- a/Source/SDK/ClientBuilder.cs
+++ b/Source/SDK/ClientBuilder.cs
@@ -56,7 +56,7 @@ namespace Dolittle.SDK
         CancellationToken _cancellation;
         RetryPolicy _retryPolicy;
         EventSubscriptionRetryPolicy _eventHorizonRetryPolicy;
-        Func<JsonSerializerSettings> _jsonSerializerSettingsProvider;
+        Action<JsonSerializerSettings> _jsonSerializerSettingsBuilder;
 
         ILoggerFactory _loggerFactory = LoggerFactory.Create(_ =>
             {
@@ -243,11 +243,11 @@ namespace Dolittle.SDK
         /// <summary>
         /// Sets the <see cref="JsonSerializerSettings"/> for serializing events.
         /// </summary>
-        /// <param name="jsonSerializerSettingsProvider"><see cref="Func{T}"/> that provides <see cref="JsonSerializerSettings"/>.</param>
+        /// <param name="jsonSerializerSettingsBuilder"><see cref="Action{T}"/> that gets called with <see cref="JsonSerializerSettings"/> to modify settings.</param>
         /// <returns>The client builder for continuation.</returns>
-        public ClientBuilder WithEventSerializerSettings(Func<JsonSerializerSettings> jsonSerializerSettingsProvider)
+        public ClientBuilder WithEventSerializerSettings(Action<JsonSerializerSettings> jsonSerializerSettingsBuilder)
         {
-            _jsonSerializerSettingsProvider = jsonSerializerSettingsProvider;
+            _jsonSerializerSettingsBuilder = jsonSerializerSettingsBuilder;
             return this;
         }
 
@@ -275,7 +275,16 @@ namespace Dolittle.SDK
                 executionContext,
                 _loggerFactory);
 
-            var serializer = new EventContentSerializer(eventTypes, _jsonSerializerSettingsProvider);
+            Func<JsonSerializerSettings> jsonSerializerSettingsProvider = () =>
+            {
+                var settings = new JsonSerializerSettings();
+                _jsonSerializerSettingsBuilder?.Invoke(settings);
+                return settings;
+            };
+
+            var serializer = new EventContentSerializer(
+                eventTypes,
+                jsonSerializerSettingsProvider);
             var eventToProtobufConverter = new EventToProtobufConverter(serializer);
             var eventToSDKConverter = new EventToSDKConverter(serializer);
             var aggregateEventToProtobufConverter = new AggregateEventToProtobufConverter(serializer);

--- a/Source/SDK/ClientBuilder.cs
+++ b/Source/SDK/ClientBuilder.cs
@@ -56,7 +56,7 @@ namespace Dolittle.SDK
         CancellationToken _cancellation;
         RetryPolicy _retryPolicy;
         EventSubscriptionRetryPolicy _eventHorizonRetryPolicy;
-        JsonSerializerSettings _jsonSerializerSettings;
+        Func<JsonSerializerSettings> _jsonSerializerSettingsProvider;
 
         ILoggerFactory _loggerFactory = LoggerFactory.Create(_ =>
             {
@@ -243,11 +243,11 @@ namespace Dolittle.SDK
         /// <summary>
         /// Sets the <see cref="JsonSerializerSettings"/> for serializing events.
         /// </summary>
-        /// <param name="jsonSerializerSettings">The default <see cref="JsonSerializerSettings"/>.</param>
+        /// <param name="jsonSerializerSettingsProvider"><see cref="Func{T}"/> that provides <see cref="JsonSerializerSettings"/>.</param>
         /// <returns>The client builder for continuation.</returns>
-        public ClientBuilder WithEventSerializerSettings(JsonSerializerSettings jsonSerializerSettings)
+        public ClientBuilder WithEventSerializerSettings(Func<JsonSerializerSettings> jsonSerializerSettingsProvider)
         {
-            _jsonSerializerSettings = jsonSerializerSettings;
+            _jsonSerializerSettingsProvider = jsonSerializerSettingsProvider;
             return this;
         }
 
@@ -275,7 +275,7 @@ namespace Dolittle.SDK
                 executionContext,
                 _loggerFactory);
 
-            var serializer = new EventContentSerializer(eventTypes, _jsonSerializerSettings);
+            var serializer = new EventContentSerializer(eventTypes, _jsonSerializerSettingsProvider);
             var eventToProtobufConverter = new EventToProtobufConverter(serializer);
             var eventToSDKConverter = new EventToSDKConverter(serializer);
             var aggregateEventToProtobufConverter = new AggregateEventToProtobufConverter(serializer);

--- a/Source/SDK/ClientBuilder.cs
+++ b/Source/SDK/ClientBuilder.cs
@@ -241,7 +241,7 @@ namespace Dolittle.SDK
         }
 
         /// <summary>
-        /// Sets the <see cref="JsonSerializerSettings"/> for serializing events.
+        /// Sets a callback that configures the <see cref="JsonSerializerSettings"/> for serializing events.
         /// </summary>
         /// <param name="jsonSerializerSettingsBuilder"><see cref="Action{T}"/> that gets called with <see cref="JsonSerializerSettings"/> to modify settings.</param>
         /// <returns>The client builder for continuation.</returns>


### PR DESCRIPTION
## Summary

Adding the ability to set a default `JsonSerializerSettings` instance for the serialization and deserialization of events. This allows for completely custom settings e.g. adding converters for types or casing configuration or similar. Fixes #70.

Using it would then be as follows during the building of the client:

```csharp
client
   .ForMicroservice(...)
   .WithJsonSerializerSettings(new JsonSerializerSettings { Converters = .... });
```

### Added

- Ability to set a default `JsonSerializerSettings` instance.
- `EventContentSerializer` honoring the default `JsonSerializerSettings`.

