### PR TITLE
Release PR 71

### DIFF
--- a/Source/Embeddings/Builder/ConventionEmbeddingBuilder.cs
+++ b/Source/Embeddings/Builder/ConventionEmbeddingBuilder.cs
@@ -48,7 +48,7 @@ namespace Dolittle.SDK.Embeddings.Builder
 
             if (!TryGetEmbeddingId(out var embeddingId))
             {
-                logger.LogWarning("The embedding class {EmbeddingType} needs to be decorated with an [{EmbeddingAttribute}]", _embeddingType, typeof(EmbeddingAttribute).Name);
+                logger.LogWarning("The embedding class {EmbeddingType} needs to be decorated with an [{EmbeddingAttribute}]", _embeddingType, nameof(EmbeddingAttribute));
                 return;
             }
 


### PR DESCRIPTION
## Summary

This PR is combined with PR #71 

Adding the ability to set a default `JsonSerializerSettings` instance for the serialization and deserialization of events. This allows for completely custom settings e.g. adding converters for types or casing configuration or similar. Fixes #70.

Using it would then be as follows during the building of the client:

```csharp
client
   .ForMicroservice(...)
   .WithJsonSerializerSettings(new JsonSerializerSettings { Converters = .... });
```

### Added

- Ability to set a default `JsonSerializerSettings` instance.
- `EventContentSerializer` honoring the default `JsonSerializerSettings`.
