### PR TITLE
Update versions and add event handler alias the whole way

### DIFF
--- a/Samples/Tutorials/GettingStarted/DishHandler.cs
+++ b/Samples/Tutorials/GettingStarted/DishHandler.cs
@@ -13,6 +13,7 @@ namespace Kitchen
     {
         public void Handle(DishPrepared @event, EventContext eventContext)
         {
+            // throw new Exception();
             Console.WriteLine($"{@event.Chef} has prepared {@event.Dish}. Yummm!");
         }
     }

--- a/Samples/Tutorials/GettingStarted/DishHandler.cs
+++ b/Samples/Tutorials/GettingStarted/DishHandler.cs
@@ -13,7 +13,6 @@ namespace Kitchen
     {
         public void Handle(DishPrepared @event, EventContext eventContext)
         {
-            // throw new Exception();
             Console.WriteLine($"{@event.Chef} has prepared {@event.Dish}. Yummm!");
         }
     }

--- a/Source/Events.Handling/Builder/ConventionEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/ConventionEventHandlerBuilder.cs
@@ -91,7 +91,7 @@ namespace Dolittle.SDK.Events.Handling.Builder
 
             var eventHandler = hasAlias 
                 ? new EventHandler(eventHandlerId, alias, scopeId, partitioned, eventTypesToMethods)
-                : new EventHandler(eventHandlerId, nameof(EventHandlerType), scopeId, partitioned, eventTypesToMethods);
+                : new EventHandler(eventHandlerId, EventHandlerType.Name, scopeId, partitioned, eventTypesToMethods);
             var eventHandlerProcessor = new EventHandlerProcessor(
                 eventHandler,
                 processingConverter,

--- a/Source/Events.Handling/Builder/ConventionEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/ConventionEventHandlerBuilder.cs
@@ -64,7 +64,7 @@ namespace Dolittle.SDK.Events.Handling.Builder
             CancellationToken cancellation)
         {
             logger.LogDebug("Building event handler from type {EventHandler}", EventHandlerType);
-            if (!TryGetEventHandlerInformation(out var eventHandlerId, out var partitioned, out var scopeId))
+            if (!TryGetEventHandlerInformation(out var eventHandlerId, out var partitioned, out var scopeId, out var alias, out var hasAlias))
             {
                 logger.LogWarning("The event handler class {EventHandlerType} needs to be decorated with an [{EventHandlerAttribute}]", EventHandlerType, typeof(EventHandlerAttribute).Name);
             }
@@ -89,7 +89,9 @@ namespace Dolittle.SDK.Events.Handling.Builder
                 return;
             }
 
-            var eventHandler = new EventHandler(eventHandlerId, scopeId, partitioned, eventTypesToMethods);
+            var eventHandler = hasAlias 
+                ? new EventHandler(eventHandlerId, alias, scopeId, partitioned, eventTypesToMethods)
+                : new EventHandler(eventHandlerId, nameof(EventHandlerType), scopeId, partitioned, eventTypesToMethods);
             var eventHandlerProcessor = new EventHandlerProcessor(
                 eventHandler,
                 processingConverter,
@@ -316,17 +318,24 @@ namespace Dolittle.SDK.Events.Handling.Builder
             return okay;
         }
 
-        bool TryGetEventHandlerInformation(out EventHandlerId eventHandlerId, out bool partitioned, out ScopeId scopeId)
+        bool TryGetEventHandlerInformation(out EventHandlerId eventHandlerId, out bool partitioned, out ScopeId scopeId, out EventHandlerAlias alias, out bool hasAlias)
         {
             eventHandlerId = default;
             partitioned = default;
             scopeId = default;
+            alias = default;
+            hasAlias = default;
             var eventHandler = EventHandlerType.GetCustomAttributes(typeof(EventHandlerAttribute), true).FirstOrDefault() as EventHandlerAttribute;
-            if (eventHandler == default) return false;
+            if (eventHandler == default)
+            {
+                return false;
+            }
 
             eventHandlerId = eventHandler.Identifier;
             partitioned = eventHandler.Partitioned;
             scopeId = eventHandler.Scope;
+            alias = eventHandler.Alias;
+            hasAlias = eventHandler.HasAlias;
             return true;
         }
 

--- a/Source/Events.Handling/Builder/EventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/EventHandlerBuilder.cs
@@ -20,6 +20,8 @@ namespace Dolittle.SDK.Events.Handling.Builder
 
         ScopeId _scopeId = ScopeId.Default;
 
+        EventHandlerAlias _alias;
+        bool _hasAlias;
         bool _partitioned = true;
 
         /// <summary>
@@ -63,6 +65,18 @@ namespace Dolittle.SDK.Events.Handling.Builder
             return this;
         }
 
+        /// <summary>
+        /// Defines the event handler to have a specific <see cref="EventHandlerAlias" />.
+        /// </summary>
+        /// <param name="alias">The <see cref="EventHandlerAlias" />.</param>
+        /// <returns>The builder for continuation.</returns>
+        public EventHandlerBuilder WithAlias(EventHandlerAlias alias)
+        {
+            _alias = alias;
+            _hasAlias = true;
+            return this;
+        }
+
         /// <inheritdoc/>
         public void BuildAndRegister(
             IEventProcessors eventProcessors,
@@ -93,7 +107,9 @@ namespace Dolittle.SDK.Events.Handling.Builder
                 return;
             }
 
-            var eventHandler = new EventHandler(_eventHandlerId, _scopeId, _partitioned, eventTypesToMethods);
+            var eventHandler = _hasAlias
+                ? new EventHandler(_eventHandlerId, _alias, _scopeId, _partitioned, eventTypesToMethods)
+                : new EventHandler(_eventHandlerId, _scopeId, _partitioned, eventTypesToMethods);
             var eventHandlerProcessor = new EventHandlerProcessor(eventHandler, processingConverter, loggerFactory.CreateLogger<EventHandlerProcessor>());
             eventProcessors.Register(
                 eventHandlerProcessor,

--- a/Source/Events.Handling/EventHandler.cs
+++ b/Source/Events.Handling/EventHandler.cs
@@ -21,7 +21,7 @@ namespace Dolittle.SDK.Events.Handling
         /// </summary>
         /// <param name="identifier">The <see cref="EventHandlerId" />.</param>
         /// <param name="scopeId">The <see cref="ScopeId" />.</param>
-        /// <param name="partitioned">The value indcating whether the <see cref="EventHandler" /> is partitioned.</param>
+        /// <param name="partitioned">The value indicating whether the <see cref="EventHandler" /> is partitioned.</param>
         /// <param name="eventHandlerMethods">The event handler methods by <see cref="EventType" />.</param>
         public EventHandler(
             EventHandlerId identifier,
@@ -35,6 +35,26 @@ namespace Dolittle.SDK.Events.Handling
             _eventHandlerMethods = eventHandlerMethods;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventHandler"/> class.
+        /// </summary>
+        /// <param name="identifier">The <see cref="EventHandlerId" />.</param>
+        /// <param name="alias">The <see cref="EventHandlerAlias"/>.</param>
+        /// <param name="scopeId">The <see cref="ScopeId" />.</param>
+        /// <param name="partitioned">The value indicating whether the <see cref="EventHandler" /> is partitioned.</param>
+        /// <param name="eventHandlerMethods">The event handler methods by <see cref="EventType" />.</param>
+        public EventHandler(
+            EventHandlerId identifier,
+            EventHandlerAlias alias,
+            ScopeId scopeId,
+            bool partitioned,
+            IDictionary<EventType, IEventHandlerMethod> eventHandlerMethods)
+            : this(identifier, scopeId, partitioned, eventHandlerMethods)
+        {
+            Alias = alias;
+            HasAlias = true;
+        }
+
         /// <inheritdoc/>
         public EventHandlerId Identifier { get; }
 
@@ -46,6 +66,12 @@ namespace Dolittle.SDK.Events.Handling
 
         /// <inheritdoc/>
         public IEnumerable<EventType> HandledEvents => _eventHandlerMethods.Keys;
+
+        /// <inheritdoc />
+        public EventHandlerAlias Alias { get; }
+
+        /// <inheritdoc />
+        public bool HasAlias { get; }
 
         /// <inheritdoc/>
         public async Task Handle(object @event, EventType eventType, EventContext context, CancellationToken cancellation)

--- a/Source/Events.Handling/EventHandlerAlias.cs
+++ b/Source/Events.Handling/EventHandlerAlias.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.SDK.Concepts;
+
+namespace Dolittle.SDK.Events.Handling
+{
+    /// <summary>
+    /// Represents the concept of the alias for an Event Handler.
+    /// </summary>
+    public class EventHandlerAlias : ConceptAs<string>
+    {
+        /// <summary>
+        /// Implicitly converts from a <see cref="string"/> to an <see cref="EventHandlerAlias"/>.
+        /// </summary>
+        /// <param name="alias">The <see cref="string"/> representation.</param>
+        /// <returns>The converted <see cref="EventHandlerAlias"/>.</returns>
+        public static implicit operator EventHandlerAlias(string alias) => new EventHandlerAlias { Value = alias };
+    }
+}

--- a/Source/Events.Handling/EventHandlerAlias.cs
+++ b/Source/Events.Handling/EventHandlerAlias.cs
@@ -6,7 +6,7 @@ using Dolittle.SDK.Concepts;
 namespace Dolittle.SDK.Events.Handling
 {
     /// <summary>
-    /// Represents the concept of the alias for an Event Handler.
+    /// Represents the concept of an alias for an Event Handler.
     /// </summary>
     public class EventHandlerAlias : ConceptAs<string>
     {

--- a/Source/Events.Handling/EventHandlerAttribute.cs
+++ b/Source/Events.Handling/EventHandlerAttribute.cs
@@ -17,11 +17,17 @@ namespace Dolittle.SDK.Events.Handling
         /// <param name="eventHandlerId">The unique identifier of the event handler.</param>
         /// <param name="partitioned">Whether the event handler is partitioned.</param>
         /// <param name="inScope">The scope that the event handler handles events in.</param>
-        public EventHandlerAttribute(string eventHandlerId, bool partitioned = true, string inScope = default)
+        /// <param name="alias">The alias for the event handler.</param>
+        public EventHandlerAttribute(string eventHandlerId, bool partitioned = true, string inScope = default, string alias = default)
         {
             Identifier = Guid.Parse(eventHandlerId);
             Partitioned = partitioned;
-            Scope = inScope == default ? ScopeId.Default : inScope;
+            Scope = inScope ?? ScopeId.Default;
+            if (alias != default)
+            {
+                Alias = alias;
+                HasAlias = true;
+            }
         }
 
         /// <summary>
@@ -32,11 +38,21 @@ namespace Dolittle.SDK.Events.Handling
         /// <summary>
         /// Gets a value indicating whether this event handler is partitioned.
         /// </summary>
-        public bool Partitioned { get; }
+        public bool Partitioned { get; }
 
         /// <summary>
         /// Gets the <see cref="ScopeId" />.
         /// </summary>
         public ScopeId Scope { get; }
+
+        /// <summary>
+        /// Gets the <see cref="EventHandlerAlias"/>.
+        /// </summary>
+        public EventHandlerAlias Alias { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this event handler has an alias.
+        /// </summary>
+        public bool HasAlias { get; }
     }
 }

--- a/Source/Events.Handling/IEventHandler.cs
+++ b/Source/Events.Handling/IEventHandler.cs
@@ -33,10 +33,20 @@ namespace Dolittle.SDK.Events.Handling
         IEnumerable<EventType> HandledEvents { get; }
 
         /// <summary>
+        /// Gets the alias of the event handler.
+        /// </summary>
+        EventHandlerAlias Alias { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the event handler has an alias or not.
+        /// </summary>
+        bool HasAlias { get; }
+
+        /// <summary>
         /// Handle an event.
         /// </summary>
         /// <param name="event">The event to handle.</param>
-        /// <param name="eventType">The artifact representign the event type.</param>
+        /// <param name="eventType">The artifact representing the event type.</param>
         /// <param name="context">The context in which the event is in.</param>
         /// <param name="cancellation">The <see cref="CancellationToken" /> used to cancel the processing of the request.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous action.</returns>

--- a/Source/Events.Handling/Internal/EventHandlerProcessor.cs
+++ b/Source/Events.Handling/Internal/EventHandlerProcessor.cs
@@ -49,6 +49,11 @@ namespace Dolittle.SDK.Events.Handling.Internal
                         ScopeId = _eventHandler.ScopeId.ToProtobuf(),
                         Partitioned = _eventHandler.Partitioned
                     };
+                    if (_eventHandler.HasAlias)
+                    {
+                        registrationRequest.Alias = _eventHandler.Alias.Value;
+                    }
+
                     registrationRequest.EventTypes.AddRange(_eventHandler.HandledEvents.Select(_ => _.ToProtobuf()).ToArray());
                     return registrationRequest;
                 }

--- a/versions.props
+++ b/versions.props
@@ -1,10 +1,10 @@
 <Project>
     <PropertyGroup>
-        <ContractsVersion>6.0.0</ContractsVersion>
+        <ContractsVersion>6.1.0</ContractsVersion>
         <MicrosoftExtensionsVersion>3.1.2</MicrosoftExtensionsVersion>
         <RxVersion>4.4.1</RxVersion>
-        <ProtobufVersion>3.14.0</ProtobufVersion>
-        <GrpcVersion>2.35.0</GrpcVersion>
+        <ProtobufVersion>3.18.1</ProtobufVersion>
+        <GrpcVersion>2.41.0</GrpcVersion>
         <NewtonsoftVersion>12.0.3</NewtonsoftVersion>
         <SystemImmutableVersion>1.7.1</SystemImmutableVersion>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

Updates Grpc, protobuf and contracts dependency versions and adds the possibility to register event handlers with aliases that is useful for when using the Dolittle CLI.

### Added

- `WithAlias` build step on the fluent builder for event handlers.
- `alias` argument on the `EventHandler` attribute
- Event handler classes without the `alias` argument gets registered with an alias that is the class name.

### Changed

- Updated Grpc, protobuf and contracts dependency versions

