### PR TITLE
Release versions and nuget notes

### DIFF
--- a/.github/workflows/dotnet-library.yml
+++ b/.github/workflows/dotnet-library.yml
@@ -61,7 +61,7 @@ jobs:
         uses: dolittle/create-release-notes-action@v1
         with:
           body: ${{ steps.context.outputs.pr-body }}
-          version: ${{ steps.context.outputs.current-version }}
+          version: ${{ steps.increment-version.outputs.next-version }}
           changelog-url: https://github.com/dolittle/DotNET.SDK/blob/master/CHANGELOG.md
       - name: Create packages
         if: ${{ steps.context.outputs.should-publish == 'true' }}

--- a/.github/workflows/dotnet-library.yml
+++ b/.github/workflows/dotnet-library.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create packages
         if: ${{ steps.context.outputs.should-publish == 'true' }}
-        run: dotnet pack --no-build --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:PackageVersion=${{ steps.increment-version.outputs.next-version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+        run: dotnet pack --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:Version=${{ steps.increment-version.outputs.next-version }} -p:PackageVersion=${{ steps.increment-version.outputs.next-version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
       - name: Prepend to Changelog
         if: ${{ steps.context.outputs.should-publish == 'true' && steps.context.outputs.release-type != 'prerelease' }}

--- a/.github/workflows/dotnet-library.yml
+++ b/.github/workflows/dotnet-library.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create release notes
         id: create-release-notes
-        # if: ${{ steps.context.outputs.should-publish == 'true' }}
+        if: ${{ steps.context.outputs.should-publish == 'true' }}
         uses: dolittle/create-release-notes-action@v1
         with:
           body: ${{ steps.context.outputs.pr-body }}

--- a/.github/workflows/dotnet-library.yml
+++ b/.github/workflows/dotnet-library.yml
@@ -55,6 +55,14 @@ jobs:
           version: ${{ steps.context.outputs.current-version }}
           release-type: ${{ steps.context.outputs.release-type }}
 
+      - name: Create release notes
+        id: create-release-notes
+        # if: ${{ steps.context.outputs.should-publish == 'true' }}
+        uses: dolittle/create-release-notes-action@v1
+        with:
+          body: ${{ steps.context.outputs.pr-body }}
+          version: ${{ steps.context.outputs.current-version }}
+          changelog-url: https://github.com/dolittle/DotNET.SDK/blob/master/CHANGELOG.md
       - name: Create packages
         if: ${{ steps.context.outputs.should-publish == 'true' }}
         run: dotnet pack --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:Version=${{ steps.increment-version.outputs.next-version }} -p:PackageVersion=${{ steps.increment-version.outputs.next-version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg

--- a/default.props
+++ b/default.props
@@ -5,7 +5,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <RepositoryUrl>https://github.com/dolittle/DotNET.SDK</RepositoryUrl>
         <PackageProjectUrl>https://dolittle.io</PackageProjectUrl>
-        <PackageReleaseNotes>For full release history, see: https://github.com/dolittle/DotNET.SDK/blob/master/CHANGELOG.md</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/dolittle/DotNET.SDK/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>

--- a/default.props
+++ b/default.props
@@ -3,6 +3,9 @@
     
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
+        <RepositoryUrl>https://github.com/dolittle/DotNET.SDK</RepositoryUrl>
+        <PackageProjectUrl>https://dolittle.io</PackageProjectUrl>
+        <PackageReleaseNotes>For full release history, see: https://github.com/dolittle/DotNET.SDK/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Added the release version while building the NuGet packages to set the AssemblyVersion on the produced DLLs. Also added the new create-release-notes-action just to try it out. I need to see some outputs to check if it's going to work.