### PR TITLE
Add release notes to NuGet packages

### DIFF
--- a/.github/workflows/dotnet-library.yml
+++ b/.github/workflows/dotnet-library.yml
@@ -65,7 +65,7 @@ jobs:
           changelog-url: https://github.com/dolittle/DotNET.SDK/blob/master/CHANGELOG.md
       - name: Create packages
         if: ${{ steps.context.outputs.should-publish == 'true' }}
-        run: dotnet pack --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:Version=${{ steps.increment-version.outputs.next-version }} -p:PackageVersion=${{ steps.increment-version.outputs.next-version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+        run: dotnet pack --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:Version=${{ steps.increment-version.outputs.next-version }} -p:PackageVersion=${{ steps.increment-version.outputs.next-version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:PackageReleaseNotes="${{ steps.create-release-notes.outputs.plaintext }}"
 
       - name: Prepend to Changelog
         if: ${{ steps.context.outputs.should-publish == 'true' && steps.context.outputs.release-type != 'prerelease' }}


### PR DESCRIPTION
## Summary

This should now add these release notes to the prerelease package. The information below is not real, just testing how the formatting works.

### Added

- We added these release notes

### Changed

- Nothing was really changed

### Fixed

- No fixes either

### Removed

- We removed some pains

### Security

- The security is great

### Deprecated

- Have we ever deprecated something?
