### PR TITLE
Fix get assemblies

### DIFF
--- a/Source/Extensions.Discovery/ClientBuilderExtensions.cs
+++ b/Source/Extensions.Discovery/ClientBuilderExtensions.cs
@@ -66,7 +66,7 @@ namespace Dolittle.SDK
         static IEnumerable<Assembly> GetAllAssemblies()
         {
             return AssemblyFinder.FindAssemblies(
-                failedFile => throw new CouldNotLoadAssemblyFromFile(failedFile),
+                _ => { },
                 _ => true,
                 false);
         }


### PR DESCRIPTION
## Summary

Apparently it is very common to not be able to load some dlls (confirmed with @digitaldias), this pr removes the throwing of an exception when failed to load an assembly