### PR TITLE
Upgrade contracts

### DIFF
--- a/Source/Resources/Internal/ResourcesClient.cs
+++ b/Source/Resources/Internal/ResourcesClient.cs
@@ -21,7 +21,7 @@ namespace Dolittle.SDK.Resources.Internal
     /// </summary>
     public class ResourcesClient : IResources
     {
-        static readonly ResourcesGetMongoDbMethod _method = new ResourcesGetMongoDbMethod();
+        static readonly ResourcesGetMongoDBMethod _method = new ResourcesGetMongoDBMethod();
         readonly IPerformMethodCalls _caller;
         readonly ExecutionContext _executionContext;
         readonly ILogger _logger;

--- a/Source/Resources/Internal/ResourcesGetMongoDBMethod.cs
+++ b/Source/Resources/Internal/ResourcesGetMongoDBMethod.cs
@@ -8,15 +8,15 @@ using Grpc.Core;
 namespace Dolittle.SDK.Resources.Internal
 {
     /// <summary>
-    /// Represents a wrapper for gRPC Subscriptions.Subscribe.
+    /// Represents a wrapper for gRPC Resources.GetMongoDB.
     /// </summary>
-    public class ResourcesGetMongoDbMethod : ICanCallAUnaryMethod<GetRequest, GetMongoDbResponse>
+    public class ResourcesGetMongoDBMethod : ICanCallAUnaryMethod<GetRequest, GetMongoDBResponse>
     {
         /// <inheritdoc/>
-        public AsyncUnaryCall<GetMongoDbResponse> Call(GetRequest message, Channel channel, CallOptions callOptions)
+        public AsyncUnaryCall<GetMongoDBResponse> Call(GetRequest message, Channel channel, CallOptions callOptions)
         {
             var client = new Dolittle.Runtime.Resources.Contracts.Resources.ResourcesClient(channel);
-            return client.GetMongoDbAsync(message, callOptions);
+            return client.GetMongoDBAsync(message, callOptions);
         }
     }
 }

--- a/Source/Resources/Resources.csproj
+++ b/Source/Resources/Resources.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="../Concepts/Concepts.csproj" />
     <ProjectReference Include="../Services/Services.csproj" />
-    <ProjectReference Include="../Executon/Execution.csproj" />
+    <ProjectReference Include="../Execution/Execution.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Source/SDK/DolittleClientBuilder.cs
+++ b/Source/SDK/DolittleClientBuilder.cs
@@ -360,7 +360,7 @@ namespace Dolittle.SDK
                 projectionStoreBuilder,
                 embeddings,
                 aggregateRoots,
-                new TenantsClient(methodCaller, _loggerFactory.CreateLogger<TenantsClient>()),
+                new TenantsClient(methodCaller, executionContext, _loggerFactory.CreateLogger<TenantsClient>()),
                 new ResourcesClient(methodCaller, executionContext, _loggerFactory.CreateLogger<ResourcesClient>()),
                 _loggerFactory,
                 _cancellation);

--- a/Source/Tenancy.Client/Internal/TenantsGetAllMethod.cs
+++ b/Source/Tenancy.Client/Internal/TenantsGetAllMethod.cs
@@ -8,7 +8,7 @@ using Grpc.Core;
 namespace Dolittle.SDK.Tenancy.Client.Internal
 {
     /// <summary>
-    /// Represents a wrapper for gRPC Subscriptions.Subscribe.
+    /// Represents a wrapper for gRPC Tenants.GetAll.
     /// </summary>
     public class TenantsGetAllMethod : ICanCallAUnaryMethod<GetAllRequest, GetAllResponse>
     {

--- a/versions.props
+++ b/versions.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>6.3.0-legolas.3</ContractsVersion>
+        <ContractsVersion>6.3.0-legolas.6</ContractsVersion>
         <MicrosoftExtensionsVersion>3.1.2</MicrosoftExtensionsVersion>
         <RxVersion>4.4.1</RxVersion>
         <ProtobufVersion>3.18.1</ProtobufVersion>


### PR DESCRIPTION
Fix naming capitalisation and pass along call context (execution context) when asking for tenants as it was added to the contracts.