### PR TITLE
Custom README for packages

### DIFF
--- a/Assets/PACKAGE-README.md
+++ b/Assets/PACKAGE-README.md
@@ -1,0 +1,20 @@
+![Dolittle](https://raw.githubusercontent.com/dolittle/Runtime/master/Documentation/dolittle_negativ_horisontal_RGB.svg "Dolittle")
+
+Dolittle is a decentralized, distributed, event-driven microservice platform built to harness the power of events.
+
+This is our C# SDK, install it with:
+```shell
+dotnet add package Dolittle.SDK 
+```
+
+# Get Started
+- Try our [getting started tutorial](https://dolittle.io/docs/tutorials/getting_started/)
+- Check out our [documentation](https://dolittle.io)
+
+# Want to try another language?
+- Check out the [JavaScript and TypeScript SDK](https://github.com/dolittle/JavaScript.SDK)
+
+# Issues and Contributing
+Issues and contributions are always welcome!
+
+To learn how to contribute, please read our [contributing](https://dolittle.io/docs/contributing/) guide.

--- a/default.props
+++ b/default.props
@@ -19,6 +19,6 @@
     
     <ItemGroup>
         <None Include="$(MSBuildThisFileDirectory)/Assets/logo.png" Pack="true" PackagePath="/logo.png" />
-        <None Include="$(MSBuildThisFileDirectory)/README.md" Pack="true" PackagePath="/README.md" />
+        <None Include="$(MSBuildThisFileDirectory)/Assets/PACKAGE-README.md" Pack="true" PackagePath="/README.md" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

A new README file for packaging into NuGet Packages. NuGet doesn't support HTML, and we don't need building and VSCode information on NuGet.

### Changed

- The NuGet README file

