### PR TITLE
Remove leftover Add call when getting all projections

### DIFF
--- a/Source/Projections/Store/ProjectionStore.cs
+++ b/Source/Projections/Store/ProjectionStore.cs
@@ -158,7 +158,6 @@ public class ProjectionStore : IProjectionStore
                 {
                     throw new ReceivedDuplicateProjectionKeys(projectionId, key);
                 }
-                result.Add(key, value);
             }
         }
         return result;


### PR DESCRIPTION
Remove call to .Add in ProjectionStore.GetAll, we already call .TryAdd