### PR TITLE
Check if Dolittle Client is connected in middleware and fix configuration bug

### DIFF
--- a/Source/Extensions.AspNet/TenantScopedServiceProviderMiddleware.cs
+++ b/Source/Extensions.AspNet/TenantScopedServiceProviderMiddleware.cs
@@ -46,7 +46,7 @@ public partial class TenantScopedServiceProviderMiddleware
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task InvokeAsync(HttpContext context)
     {
-        if (_client == null)
+        if (_client is not { IsConnected: true })
         {
             DolittleClientNotReady();
             await _next(context).ConfigureAwait(false);

--- a/Source/SDK/ServiceProviderExtensions.cs
+++ b/Source/SDK/ServiceProviderExtensions.cs
@@ -33,7 +33,8 @@ public static class ServiceProviderExtensions
 
         try
         {
-            var clientConfig = provider.GetService<IOptions<DolittleClientConfiguration>>()?.Value ?? new DolittleClientConfiguration();
+            var config = provider.GetService<IOptions<Configurations.Dolittle>>()?.Value;
+            var clientConfig = config != default ? DolittleClientConfiguration.FromConfiguration(config) : new DolittleClientConfiguration();
             configureClient?.Invoke(clientConfig);
 
             return await client.Connect(clientConfig, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

Do not throw exception when using dolittle middleware and it's not connected before a request is received, and fixes a configuration bug when getting a Dolittle Client directly from the service provider.

### Fixed

- In the `TenantScopedServiceProviderMiddleware` we check if the Dolittle Client is connected and log a message if it's not
- Using the `IServiceProvider.GetDolittleClient()` got the wrong configuration object.

