### PR TITLE
Wait a second if Handling events is cancelled by server

### DIFF
--- a/Source/Events.Processing/EventProcessors.cs
+++ b/Source/Events.Processing/EventProcessors.cs
@@ -90,6 +90,12 @@ public class EventProcessors : IEventProcessors
 
                 _logger.LogInformation("{Kind} {Identifier} registered with the Runtime, start handling requests", eventProcessor.Kind, eventProcessor.Identifier);
                 await client.Handle(eventProcessor, cancellationToken).ConfigureAwait(false);
+                
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning("{Kind} {Identifier} has stopped processing, retrying in 1s", eventProcessor.Kind, eventProcessor.Identifier);
+                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                }
             }
             catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
             {


### PR DESCRIPTION
## Summary

Fixes an issue where an event processor would be re-registered immediately if reverse call client was cancelled by the server.

### Fixed

- Waits a second and logs a warning message when handling of events was cancelled by the server
