### PR TITLE
Projection alias

### DIFF
--- a/Source/Aggregates/Internal/AggregateRoots.cs
+++ b/Source/Aggregates/Internal/AggregateRoots.cs
@@ -30,10 +30,7 @@ public class AggregateRoots : IAggregateRoots
     public Try<TAggregate> TryGet<TAggregate>(EventSourceId eventSourceId)
         where TAggregate : AggregateRoot
     {
-        _logger.LogDebug(
-            "Getting aggregate root {AggregateRoot} with event source id {EventSource}",
-            typeof(TAggregate),
-            eventSourceId);
+        _logger.Get(typeof(TAggregate), eventSourceId);
         if (InvalidConstructor(typeof(TAggregate), out var constructor, out var exception))
         {
             return exception;

--- a/Source/Aggregates/Internal/AggregateRootsClient.cs
+++ b/Source/Aggregates/Internal/AggregateRootsClient.cs
@@ -68,29 +68,18 @@ public class AggregateRootsClient
 
     async Task Register(AggregateRootAliasRegistrationRequest request, CancellationToken cancellationToken)
     {
-        _logger.LogDebug(
-            "Registering Aggregate Root {AggregateRoot} with Alias {Alias}",
-            request.AggregateRoot.Id.ToGuid(),
-            request.Alias);
+        _logger.Registering(request.AggregateRoot.Id.ToGuid(), request.Alias);
         try
         {
             var response = await _caller.Call(_aliasMethod, request, cancellationToken).ConfigureAwait(false);
             if (response.Failure != null)
             {
-                _logger.LogWarning(
-                    "An error occurred while registering Aggregate Root {AggregateRoot} with Alias {Alias} because {Reason}",
-                    request.AggregateRoot.Id.ToGuid(),
-                    request.Alias,
-                    response.Failure.Reason);
+                _logger.FailedToRegister(request.AggregateRoot.Id.ToGuid(), request.Alias, response.Failure.Reason);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(
-                ex,
-                "An error occurred while registering Aggregate Root {AggregateRoot} with Alias {Alias}",
-                request.AggregateRoot.Id.ToGuid(),
-                request.Alias);
+            _logger.ErrorDuringRegister(request.AggregateRoot.Id.ToGuid(), request.Alias, ex);
         }
     }
 }

--- a/Source/Aggregates/Internal/Log.cs
+++ b/Source/Aggregates/Internal/Log.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Aggregates.Internal;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Aggregates.Internal"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Debug, "Getting aggregate root {AggregateRoot} with event source id {EventSource}")]
+    internal static partial void Get(this ILogger logger, Type aggregateRoot, EventSourceId eventSource);
+
+    [LoggerMessage(0, LogLevel.Debug, "Registering Aggregate Root {AggregateRoot} with Alias {Alias}")]
+    internal static partial void Registering(this ILogger logger, AggregateRootId aggregateRoot, AggregateRootAlias alias);
+
+    [LoggerMessage(0, LogLevel.Warning, "A failure occurred while registering Aggregate Root {AggregateRoot} with Alias {Alias} because {Reason}")]
+    internal static partial void FailedToRegister(this ILogger logger, AggregateRootId aggregateRoot, AggregateRootAlias alias, string reason);
+    
+    [LoggerMessage(0, LogLevel.Warning,"An error occurred while registering Aggregate Root {AggregateRoot} with Alias {Alias}" )]
+    internal static partial void ErrorDuringRegister(this ILogger logger, AggregateRootId aggregateRoot, AggregateRootAlias alias, Exception exception);
+}

--- a/Source/Aggregates/Log.cs
+++ b/Source/Aggregates/Log.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Aggregates;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Aggregates"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Debug,"Performing operation on {AggregateRoot} with aggregate root id {AggregateRootId} applying events to event source {EventSource}")]
+    internal static partial void PerformingOn(this ILogger logger, Type aggregateRoot, AggregateRootId aggregateRootId, EventSourceId eventSource);
+    
+    [LoggerMessage(0, LogLevel.Debug, "Re-applying events for {AggregateRoot} with aggregate root id {AggregateRootId} with event source id {EventSource}")]
+    internal static partial void ReApplyingEventsFor(this ILogger logger, Type aggregateRoot, AggregateRootId aggregateRootId, EventSourceId eventSource);
+
+    [LoggerMessage(0, LogLevel.Trace, "Re-applying {NumberOfEvents} events")]
+    internal static partial void ReApplying(this ILogger logger, int numberOfEvents);
+    
+    [LoggerMessage(0, LogLevel.Trace, "No events to re-apply")]
+    internal static partial void NoEventsToReApply(this ILogger logger);
+    
+    [LoggerMessage(0, LogLevel.Debug, "{AggregateRoot} with aggregate root id {AggregateRootId} is committing {NumberOfEvents} events to event source {EventSource}")]
+    internal static partial void CommittingEvents(this ILogger logger, Type aggregateRoot, AggregateRootId aggregateRootId, int numberOfEvents, EventSourceId eventSource);
+}

--- a/Source/Common/Model/ModelBuilder.cs
+++ b/Source/Common/Model/ModelBuilder.cs
@@ -76,10 +76,10 @@ public class ModelBuilder : IModelBuilder
             (type, identifiers) =>
             {
                 var sb = new StringBuilder();
-                sb.Append($"Type {type} is bound to multiple identifiers:");
+                sb.Append(FormattableString.Invariant($"Type {type} is bound to multiple identifiers:"));
                 foreach (var identifier in identifiers)
                 {
-                    sb.Append($"\n\t{identifier}. This binding will be ignored");
+                    sb.Append(FormattableString.Invariant($"\n\t{identifier}. This binding will be ignored"));
                 }
                 buildResults.AddFailure(sb.ToString());
             });
@@ -88,10 +88,10 @@ public class ModelBuilder : IModelBuilder
             (processorBuilder, identifiers) =>
             {
                 var sb = new StringBuilder();
-                sb.Append($"Processor Builder {processorBuilder} is bound to multiple identifiers:");
+                sb.Append(FormattableString.Invariant($"Processor Builder {processorBuilder} is bound to multiple identifiers:"));
                 foreach (var identifier in identifiers)
                 {
-                    sb.Append($"\n\t{identifier}. This binding will be ignored");
+                    sb.Append(FormattableString.Invariant($"\n\t{identifier}. This binding will be ignored"));
                 }
                 buildResults.AddFailure(sb.ToString());
             });
@@ -137,28 +137,28 @@ public class ModelBuilder : IModelBuilder
             conflicts.Add("processors");
         }
         var sb = new StringBuilder();
-        sb.Append($"The identifier {id} was bound to conflicting {string.Join(" and ", conflicts)}:");
+        sb.Append(FormattableString.Invariant($"The identifier {id} was bound to conflicting {string.Join(" and ", conflicts)}:"));
         foreach (var (binding, type)  in conflictingTypes)
         {
-            sb.Append($"\n\t{binding.Identifier} was bound to type {type.Name}. This binding will be ignored");
+            sb.Append(FormattableString.Invariant($"\n\t{binding.Identifier} was bound to type {type.Name}. This binding will be ignored"));
         }
         foreach (var (binding, processorBuilder) in conflictingProcessorBuilders)
         {
-            sb.Append($"\n\t{binding.Identifier} was bound to processor builder {processorBuilder}. This binding will be ignored");
+            sb.Append(FormattableString.Invariant($"\n\t{binding.Identifier} was bound to processor builder {processorBuilder}. This binding will be ignored"));
         }
         buildResults.AddFailure(sb.ToString());
     }
     static void AddFailedBuildResultsForCoexistentBindings(Guid id, IEnumerable<IdentifierMapBinding<Type>> coexistentTypes, IEnumerable<IdentifierMapBinding<object>> coexistentProcessorBuilders, IClientBuildResults buildResults)
     {
         var sb = new StringBuilder();
-        sb.Append($"The identifier {id} was also bound to:");
+        sb.Append(FormattableString.Invariant($"The identifier {id} was also bound to:"));
         foreach (var (binding, type) in coexistentTypes)
         {
-            sb.Append($"\n\t{binding.Identifier} binding to type {type.Name}. This binding will be ignored");
+            sb.Append(FormattableString.Invariant($"\n\t{binding.Identifier} binding to type {type.Name}. This binding will be ignored"));
         }
         foreach (var (binding, processorBuilder) in coexistentProcessorBuilders)
         {
-            sb.Append($"\n\t{binding.Identifier} binding to processor builder {processorBuilder}. This binding will be ignored");
+            sb.Append(FormattableString.Invariant($"\n\t{binding.Identifier} binding to processor builder {processorBuilder}. This binding will be ignored"));
         }
         buildResults.AddFailure(sb.ToString());
     }

--- a/Source/DependencyInversion/TenantServiceScope.cs
+++ b/Source/DependencyInversion/TenantServiceScope.cs
@@ -36,5 +36,6 @@ public class TenantServiceScope : IServiceScope
     {
         _rootScope?.Dispose();
         _tenantScope?.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/Source/Embeddings/Embedding.cs
+++ b/Source/Embeddings/Embedding.cs
@@ -69,10 +69,7 @@ public class Embedding : EmbeddingStore, IEmbedding
     /// <inheritdoc/>
     public async Task Delete(Key key, EmbeddingId embeddingId, CancellationToken cancellation = default)
     {
-        _logger.LogDebug(
-            "Deleting embedding with key {Key} and id {EmbeddingId}",
-            key,
-            embeddingId);
+        _logger.Delete(key, embeddingId);
 
         var request = new DeleteRequest
         {
@@ -101,11 +98,7 @@ public class Embedding : EmbeddingStore, IEmbedding
     public async Task<CurrentState<TEmbedding>> Update<TEmbedding>(Key key, EmbeddingId embeddingId, TEmbedding state, CancellationToken cancellation = default)
         where TEmbedding : class, new()
     {
-        _logger.LogDebug(
-            "Updating embedding state with key {Key} for embedding of {EmbeddingType} with id {EmbeddingId}",
-            key,
-            typeof(TEmbedding),
-            embeddingId);
+        _logger.Update(key, typeof(TEmbedding), embeddingId);
 
         var request = new UpdateRequest
         {
@@ -120,7 +113,7 @@ public class Embedding : EmbeddingStore, IEmbedding
 
         if (!_toSDK.TryConvert<TEmbedding>(response.State, out var retrieveState, out var error))
         {
-            _logger.LogError(error, "The Runtime returned the embedding state '{State}'. But it could not be converted to {EmbeddingType}.", response.State, typeof(TEmbedding));
+            _logger.FailedToConvertState(response.State.State, typeof(TEmbedding), error);
             throw error;
         }
 

--- a/Source/Embeddings/Embeddings.csproj
+++ b/Source/Embeddings/Embeddings.csproj
@@ -4,6 +4,7 @@
 
     <PropertyGroup>
         <AssemblyName>Dolittle.SDK.Embeddings</AssemblyName>
+        <RootNamespace>Dolittle.SDK.Embeddings</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/Embeddings/Log.cs
+++ b/Source/Embeddings/Log.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Projections;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Embeddings;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Embeddings"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Debug, "Deleting embedding with key {Key} for embedding with id {EmbeddingId}")]
+    internal static partial void Delete(this ILogger logger, Key key, EmbeddingId embeddingId);
+    
+    [LoggerMessage(0, LogLevel.Debug, "Updating embedding state with key {Key} for embedding of {EmbeddingType} with id {EmbeddingId}")]
+    internal static partial void Update(this ILogger logger, Key key, Type embeddingType, EmbeddingId embeddingId);
+    
+    [LoggerMessage(0, LogLevel.Error, "The Runtime returned the embedding state '{State}'. But it could not be converted to {EmbeddingType}.")]
+    internal static partial void FailedToConvertState(this ILogger logger, string state, Type embeddingType, Exception exception);
+}

--- a/Source/Embeddings/Store/EmbeddingStore.cs
+++ b/Source/Embeddings/Store/EmbeddingStore.cs
@@ -73,11 +73,7 @@ public class EmbeddingStore : IEmbeddingStore
     public async Task<CurrentState<TEmbedding>> Get<TEmbedding>(Key key, EmbeddingId embeddingId, CancellationToken cancellation = default)
         where TEmbedding : class, new()
     {
-        _logger.LogDebug(
-            "Getting current embedding state with key {Key} for embedding of {EmbeddingType} with id {EmbeddingId}",
-            key,
-            typeof(TEmbedding),
-            embeddingId);
+        _logger.Get(key, typeof(TEmbedding), embeddingId);
 
         var request = new GetOneRequest
         {
@@ -93,7 +89,8 @@ public class EmbeddingStore : IEmbeddingStore
         {
             return state;
         }
-        _logger.LogError(error, "The Runtime returned the embedding state '{State}'. But it could not be converted to {EmbeddingType}.", response.State, typeof(TEmbedding));
+        
+        _logger.FailedToConvertState(response.State.State, typeof(TEmbedding), error);
         throw error;
 
     }
@@ -114,10 +111,7 @@ public class EmbeddingStore : IEmbeddingStore
     public async Task<IDictionary<Key, CurrentState<TEmbedding>>> GetAll<TEmbedding>(EmbeddingId embeddingId, CancellationToken cancellation = default)
         where TEmbedding : class, new()
     {
-        _logger.LogDebug(
-            "Getting all current embedding states for embedding of {EmbeddingType} with id {EmbeddingId}",
-            typeof(TEmbedding),
-            embeddingId);
+        _logger.GetAll(typeof(TEmbedding), embeddingId);
 
         var request = new GetAllRequest
         {
@@ -132,7 +126,8 @@ public class EmbeddingStore : IEmbeddingStore
         {
             return states.ToDictionary(_ => _.Key);
         }
-        _logger.LogError(error, "The Runtime returned the embedding states '{States}'. But it could not be converted to {EmbeddingType}.", response.States, typeof(TEmbedding));
+        
+        _logger.FailedToConvertStates(response.States.Select(_ => _.State), typeof(TEmbedding), error);
         throw error;
 
     }
@@ -153,10 +148,7 @@ public class EmbeddingStore : IEmbeddingStore
     public async Task<IEnumerable<Key>> GetKeys<TEmbedding>(EmbeddingId embeddingId, CancellationToken cancellation = default)
         where TEmbedding : class, new()
     {
-        _logger.LogDebug(
-            "Getting all keys for embedding of type {EmbeddingType} with id {EmbeddingId}",
-            typeof(TEmbedding),
-            embeddingId);
+        _logger.GetKeys(typeof(TEmbedding), embeddingId);
 
         var request = new GetKeysRequest
         {

--- a/Source/Embeddings/Store/EmbeddingStore.cs
+++ b/Source/Embeddings/Store/EmbeddingStore.cs
@@ -90,7 +90,7 @@ public class EmbeddingStore : IEmbeddingStore
             return state;
         }
         
-        _logger.FailedToConvertState(response.State.State, typeof(TEmbedding), error);
+        _logger.FailedToConvertState(typeof(TEmbedding), error);
         throw error;
 
     }
@@ -127,7 +127,7 @@ public class EmbeddingStore : IEmbeddingStore
             return states.ToDictionary(_ => _.Key);
         }
         
-        _logger.FailedToConvertStates(response.States.Select(_ => _.State), typeof(TEmbedding), error);
+        _logger.FailedToConvertState(typeof(TEmbedding), error);
         throw error;
 
     }

--- a/Source/Embeddings/Store/Log.cs
+++ b/Source/Embeddings/Store/Log.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using Dolittle.SDK.Projections;
 using Microsoft.Extensions.Logging;
 
@@ -16,14 +15,11 @@ static partial class Log
     [LoggerMessage(0, LogLevel.Debug, "Getting current embedding state with key {Key} for embedding of {EmbeddingType} with id {EmbeddingId}")]
     internal static partial void Get(this ILogger logger, Key key, Type embeddingType, EmbeddingId embeddingId);
 
-    [LoggerMessage(0, LogLevel.Error, "The Runtime returned the embedding state '{State}'. But it could not be converted to {EmbeddingType}.")]
-    internal static partial void FailedToConvertState(this ILogger logger, string state, Type embeddingType, Exception exception);
+    [LoggerMessage(0, LogLevel.Error, "The embedding state returned by the Runtime could not be converted to {EmbeddingType}.")]
+    internal static partial void FailedToConvertState(this ILogger logger, Type embeddingType, Exception exception);
     
     [LoggerMessage(0, LogLevel.Debug, "Getting all current embedding states for embedding of {EmbeddingType} with id {EmbeddingId}")]
     internal static partial void GetAll(this ILogger logger, Type embeddingType, EmbeddingId embeddingId);
-    
-    [LoggerMessage(0, LogLevel.Error, "The Runtime returned the embedding state '{States}'. But it could not be converted to {EmbeddingType}.")]
-    internal static partial void FailedToConvertStates(this ILogger logger, IEnumerable<string> states, Type embeddingType, Exception exception);
     
     [LoggerMessage(0, LogLevel.Debug, "Getting all keys for embedding of {EmbeddingType} with id {EmbeddingId}")]
     internal static partial void GetKeys(this ILogger logger, Type embeddingType, EmbeddingId embeddingId);

--- a/Source/Embeddings/Store/Log.cs
+++ b/Source/Embeddings/Store/Log.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Dolittle.SDK.Projections;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Embeddings.Store;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Embeddings.Store"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Debug, "Getting current embedding state with key {Key} for embedding of {EmbeddingType} with id {EmbeddingId}")]
+    internal static partial void Get(this ILogger logger, Key key, Type embeddingType, EmbeddingId embeddingId);
+
+    [LoggerMessage(0, LogLevel.Error, "The Runtime returned the embedding state '{State}'. But it could not be converted to {EmbeddingType}.")]
+    internal static partial void FailedToConvertState(this ILogger logger, string state, Type embeddingType, Exception exception);
+    
+    [LoggerMessage(0, LogLevel.Debug, "Getting all current embedding states for embedding of {EmbeddingType} with id {EmbeddingId}")]
+    internal static partial void GetAll(this ILogger logger, Type embeddingType, EmbeddingId embeddingId);
+    
+    [LoggerMessage(0, LogLevel.Error, "The Runtime returned the embedding state '{States}'. But it could not be converted to {EmbeddingType}.")]
+    internal static partial void FailedToConvertStates(this ILogger logger, IEnumerable<string> states, Type embeddingType, Exception exception);
+    
+    [LoggerMessage(0, LogLevel.Debug, "Getting all keys for embedding of {EmbeddingType} with id {EmbeddingId}")]
+    internal static partial void GetKeys(this ILogger logger, Type embeddingType, EmbeddingId embeddingId);
+}

--- a/Source/EventHorizon/EventHorizon.csproj
+++ b/Source/EventHorizon/EventHorizon.csproj
@@ -4,6 +4,7 @@
 
     <PropertyGroup>
         <AssemblyName>Dolittle.SDK.EventHorizon</AssemblyName>
+        <RootNamespace>Dolittle.SDK.EventHorizon</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/EventHorizon/EventHorizons.cs
+++ b/Source/EventHorizon/EventHorizons.cs
@@ -126,8 +126,7 @@ public class EventHorizons : IEventHorizons, IDisposable
         {
             try
             {
-                _logger.LogDebug(
-                    "Subscribing to events from {ProducerMicroservice} in {ProducerTenant} in {ProducerStream} in {ProducerPartition} for {ConsumerTenant} into {ConsumerScope}",
+                _logger.SubscribingTo(
                     subscription.ProducerMicroservice,
                     subscription.ProducerTenant,
                     subscription.ProducerStream,
@@ -140,8 +139,7 @@ public class EventHorizons : IEventHorizons, IDisposable
 
                 if (response.Failed)
                 {
-                    _logger.LogWarning(
-                        "Failed to subscribe to events from {ProducerMicroservice} in {ProducerTenant} in {ProducerStream} in {ProducerPartition} for {ConsumerTenant} into {ConsumerScope} because {Reason}",
+                    _logger.FailedToSubscribeTo(
                         subscription.ProducerMicroservice,
                         subscription.ProducerTenant,
                         subscription.ProducerStream,
@@ -152,8 +150,7 @@ public class EventHorizons : IEventHorizons, IDisposable
                 }
                 else
                 {
-                    _logger.LogDebug(
-                        "Successfully subscribed to events from {ProducerMicroservice} in {ProducerTenant} in {ProducerStream} in {ProducerPartition} for {ConsumerTenant} into {ConsumerScope} with {Consent}",
+                    _logger.SuccessfullySubscribedTo(
                         subscription.ProducerMicroservice,
                         subscription.ProducerTenant,
                         subscription.ProducerStream,
@@ -167,7 +164,7 @@ public class EventHorizons : IEventHorizons, IDisposable
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "An exception was thrown while registering an event horizon subscription.");
+                _logger.ErrorWhileRegisteringSubscription(ex);
             }
 
             return false;

--- a/Source/EventHorizon/Log.cs
+++ b/Source/EventHorizon/Log.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Failures;
+using Dolittle.SDK.Microservices;
+using Dolittle.SDK.Tenancy;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.EventHorizon;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.EventHorizon"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Debug, "Subscribing to events from {ProducerMicroservice} in {ProducerTenant} in {ProducerStream} in {ProducerPartition} for {ConsumerTenant} into {ConsumerScope}")]
+    internal static partial void SubscribingTo(
+        this ILogger logger,
+        MicroserviceId producerMicroservice,
+        TenantId producerTenant,
+        StreamId producerStream,
+        PartitionId producerPartition,
+        TenantId consumerTenant,
+        ScopeId consumerScope);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Failed to subscribe to events from {ProducerMicroservice} in {ProducerTenant} in {ProducerStream} in {ProducerPartition} for {ConsumerTenant} into {ConsumerScope} because {Reason}")]
+    internal static partial void FailedToSubscribeTo(
+        this ILogger logger,
+        MicroserviceId producerMicroservice,
+        TenantId producerTenant,
+        StreamId producerStream,
+        PartitionId producerPartition,
+        TenantId consumerTenant,
+        ScopeId consumerScope,
+        FailureReason reason);
+    
+    [LoggerMessage(0, LogLevel.Debug, "Successfully subscribed to events from {ProducerMicroservice} in {ProducerTenant} in {ProducerStream} in {ProducerPartition} for {ConsumerTenant} into {ConsumerScope} with {Consent}")]
+    internal static partial void SuccessfullySubscribedTo(
+        this ILogger logger,
+        MicroserviceId producerMicroservice,
+        TenantId producerTenant,
+        StreamId producerStream,
+        PartitionId producerPartition,
+        TenantId consumerTenant,
+        ScopeId consumerScope,
+        ConsentId consent);
+
+    [LoggerMessage(0, LogLevel.Warning, "An exception was thrown while registering an event horizon subscription.")]
+    internal static partial void ErrorWhileRegisteringSubscription(this ILogger logger, Exception exception);
+}

--- a/Source/Events.Handling/Builder/Convention/ConventionEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/Convention/ConventionEventHandlerBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -14,7 +15,7 @@ namespace Dolittle.SDK.Events.Handling.Builder.Convention;
 /// <summary>
 /// Methods for building <see cref="IEventHandler"/> instances by convention from an instantiated event handler class.
 /// </summary>
-public abstract class ConventionEventHandlerBuilder : ICanTryBuildEventHandler
+public abstract class ConventionEventHandlerBuilder : ICanTryBuildEventHandler, IEquatable<ICanTryBuildEventHandler>
 {
     const string MethodName = "Handle";
     
@@ -54,8 +55,13 @@ public abstract class ConventionEventHandlerBuilder : ICanTryBuildEventHandler
         }
 
         return other is ConventionEventHandlerBuilder otherBuilder
-            && EventHandlerType == otherBuilder.EventHandlerType && _eventHandlerInstance.Equals(otherBuilder._eventHandlerInstance);
+            && EventHandlerType == otherBuilder.EventHandlerType
+            && _eventHandlerInstance.Equals(otherBuilder._eventHandlerInstance);
     }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(_decorator, _eventHandlerInstance, EventHandlerType);
     
     /// <summary>
     /// Builds event handler.

--- a/Source/Events.Handling/Builder/Convention/Instance/ConventionInstanceEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/Convention/Instance/ConventionInstanceEventHandlerBuilder.cs
@@ -32,7 +32,15 @@ public class ConventionInstanceEventHandlerBuilder : ConventionEventHandlerBuild
     
     /// <inheritdoc />
     public bool Equals(ConventionInstanceEventHandlerBuilder other)
-        => other is not null && ((ICanTryBuildEventHandler)this).Equals(other as ICanTryBuildEventHandler);
+        => other is not null && ((ICanTryBuildEventHandler)this).Equals(other);
+
+    /// <inheritdoc />
+    public override bool Equals(object other)
+        => Equals(other as ConventionInstanceEventHandlerBuilder);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => base.GetHashCode();
 
     /// <inheritdoc/>
     public override bool TryBuild(

--- a/Source/Events.Handling/Builder/Convention/Type/ConventionTypeEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/Convention/Type/ConventionTypeEventHandlerBuilder.cs
@@ -26,7 +26,15 @@ public class ConventionTypeEventHandlerBuilder : ConventionEventHandlerBuilder, 
     
     /// <inheritdoc />
     public bool Equals(ConventionTypeEventHandlerBuilder other)
-        => other is not null && ((ICanTryBuildEventHandler)this).Equals(other as ICanTryBuildEventHandler);
+        => other is not null && ((ICanTryBuildEventHandler)this).Equals(other);
+
+    /// <inheritdoc />
+    public override bool Equals(object other)
+        => Equals(other as ConventionTypeEventHandlerBuilder);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => base.GetHashCode();
 
     /// <inheritdoc/>
     public override bool TryBuild(

--- a/Source/Events.Handling/Builder/EventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/EventHandlerBuilder.cs
@@ -92,7 +92,16 @@ public class EventHandlerBuilder : IEventHandlerBuilder, ICanTryBuildEventHandle
     }
     
     /// <inheritdoc />
-    public bool Equals(EventHandlerBuilder other) => ReferenceEquals(this, other);
+    public bool Equals(EventHandlerBuilder other)
+        => ReferenceEquals(this, other);
+
+    /// <inheritdoc />
+    public override bool Equals(object other)
+        => Equals(other as EventHandlerBuilder);
+
+    /// <inheritdoc />
+    public override int GetHashCode() =>
+        HashCode.Combine(_eventHandlerId, _methodsBuilder, _alias, _hasAlias, _partitioned, _scopeId);
 
     void Bind()
     {

--- a/Source/Events.Handling/Builder/IEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/IEventHandlerBuilder.cs
@@ -14,25 +14,25 @@ public interface IEventHandlerBuilder
     /// Defines the event handler to be partitioned - this is default for an event handler.
     /// </summary>
     /// <returns>The builder for continuation.</returns>
-    public IEventHandlerMethodsBuilder Partitioned();
+    IEventHandlerMethodsBuilder Partitioned();
 
     /// <summary>
     /// Defines the event handler to be unpartitioned. By default it will be partitioned.
     /// </summary>
     /// <returns>The builder for continuation.</returns>
-    public IEventHandlerMethodsBuilder Unpartitioned();
+    IEventHandlerMethodsBuilder Unpartitioned();
 
     /// <summary>
     /// Defines the event handler to operate on a specific <see cref="ScopeId" />.
     /// </summary>
     /// <param name="scopeId">The <see cref="ScopeId" />.</param>
     /// <returns>The builder for continuation.</returns>
-    public IEventHandlerBuilder InScope(ScopeId scopeId);
+    IEventHandlerBuilder InScope(ScopeId scopeId);
 
     /// <summary>
     /// Defines the event handler to have a specific <see cref="EventHandlerAlias" />.
     /// </summary>
     /// <param name="alias">The <see cref="EventHandlerAlias" />.</param>
     /// <returns>The builder for continuation.</returns>
-    public IEventHandlerBuilder WithAlias(EventHandlerAlias alias);
+    IEventHandlerBuilder WithAlias(EventHandlerAlias alias);
 }

--- a/Source/Events.Handling/EventHandlerAttribute.cs
+++ b/Source/Events.Handling/EventHandlerAttribute.cs
@@ -24,12 +24,11 @@ public class EventHandlerAttribute : Attribute, IDecoratedTypeDecorator<EventHan
         Identifier = Guid.Parse(eventHandlerId);
         Partitioned = partitioned;
         Scope = inScope ?? ScopeId.Default;
-        if (alias == default)
+        if (alias != default)
         {
-            return;
+            Alias = alias;
+            HasAlias = true;
         }
-        Alias = alias;
-        HasAlias = true;
     }
 
     /// <summary>

--- a/Source/Events.Processing/Events.Processing.csproj
+++ b/Source/Events.Processing/Events.Processing.csproj
@@ -4,6 +4,7 @@
 
     <PropertyGroup>
         <AssemblyName>Dolittle.SDK.Events.Processing</AssemblyName>
+        <RootNamespace>Dolittle.SDK.Events.Processing</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/Events.Processing/Internal/EventProcessor.cs
+++ b/Source/Events.Processing/Internal/EventProcessor.cs
@@ -77,7 +77,7 @@ public abstract class EventProcessor<TIdentifier, TRegisterArguments, TRequest, 
                 RetryTimeout = retryTimeout
             };
 
-            _logger.LogWarning(ex, "Processing in {Kind} {Identifier} failed. Will retry in {RetrySeconds}", Kind, Identifier, retrySeconds);
+            _logger.ProcessingFailed(Kind, Identifier, retrySeconds, ex);
 
             return CreateResponseFromFailure(failure);
         }

--- a/Source/Events.Processing/Internal/Log.cs
+++ b/Source/Events.Processing/Internal/Log.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Concepts;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Events.Processing.Internal;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Events.Processing.Internal"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Warning, "Processing in {Kind} {Identifier} failed. Will retry in {RetrySeconds}")]
+    internal static partial void ProcessingFailed(this ILogger logger, EventProcessorKind kind, ConceptAs<Guid> identifier, uint retrySeconds, Exception exception);
+}

--- a/Source/Events.Processing/Log.cs
+++ b/Source/Events.Processing/Log.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Concepts;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Events.Processing;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Events.Processing"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Warning, "{Kind} {Identifier} failed to connect to the Runtime, retrying in 1s")]
+    internal static partial void FailedToConnectToRuntime(this ILogger logger, EventProcessorKind kind, ConceptAs<Guid> identifier);
+    
+    [LoggerMessage(0, LogLevel.Warning, "{Kind} {Identifier} received a failure from the Runtime, retrying in 1s. {FailureReason}")]
+    internal static partial void ReceivedFailureFromRuntime(this ILogger logger, EventProcessorKind kind, ConceptAs<Guid> identifier, string failureReason);
+    
+    [LoggerMessage(0, LogLevel.Information, "{Kind} {Identifier} registered with the Runtime, start handling requests")]
+    internal static partial void Registered(this ILogger logger, EventProcessorKind kind, ConceptAs<Guid> identifier);
+    
+    [LoggerMessage(0, LogLevel.Warning, "{Kind} {Identifier} has stopped processing, retrying in 1s")]
+    internal static partial void StoppedDuringProcessing(this ILogger logger, EventProcessorKind kind, ConceptAs<Guid> identifier);
+    
+    [LoggerMessage(0, LogLevel.Warning, "{Kind} {Identifier} registration failed with exception, retrying in 1s")]
+    internal static partial void RegistrationFailed(this ILogger logger, EventProcessorKind kind, ConceptAs<Guid> identifier, Exception exception);
+    
+    [LoggerMessage(0, LogLevel.Debug, "{Kind} {identifier} handling of requests stopped")]
+    internal static partial void ProcessingCompleted(this ILogger logger, EventProcessorKind kind, ConceptAs<Guid> identifier);
+}

--- a/Source/Events/EventLogSequenceNumber.cs
+++ b/Source/Events/EventLogSequenceNumber.cs
@@ -13,7 +13,7 @@ public record EventLogSequenceNumber(ulong Value) : ConceptAs<ulong>(Value)
     /// <summary>
     /// The initial version of the Event Store before any Events are committed.
     /// </summary>
-    public static EventLogSequenceNumber Initial = 0;
+    public static EventLogSequenceNumber Initial => 0;
 
     /// <summary>
     /// Implicitly convert a <see cref="uint"/> to an <see cref="EventLogSequenceNumber"/>.

--- a/Source/Events/Internal/EventTypesClient.cs
+++ b/Source/Events/Internal/EventTypesClient.cs
@@ -70,29 +70,18 @@ public class EventTypesClient
 
     async Task Register(EventTypeRegistrationRequest request, CancellationToken cancellationToken)
     {
-        _logger.LogDebug(
-            "Registering Event Type {EventType} with Alias {Alias}",
-            request.EventType.Id.ToGuid(),
-            request.Alias);
+        _logger.Registering(request.EventType.Id.ToGuid(), request.Alias);
         try
         {
             var response = await _caller.Call(_method, request, cancellationToken).ConfigureAwait(false);
             if (response.Failure != null)
             {
-                _logger.LogWarning(
-                    "An error occurred while registering Event Type {EventType} with Alias {Alias} because {Reason}",
-                    request.EventType.Id.ToGuid(),
-                    request.Alias,
-                    response.Failure.Reason);
+                _logger.FailedToRegister(request.EventType.Id.ToGuid(), request.Alias, response.Failure.Reason);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(
-                ex,
-                "An error occurred while registering Event Type {EventType} with Alias {Alias}",
-                request.EventType.Id.ToGuid(),
-                request.Alias);
+            _logger.ErrorWhileRegistering(request.EventType.Id.ToGuid(), request.Alias, ex);
         }
     }
 }

--- a/Source/Events/Internal/Log.cs
+++ b/Source/Events/Internal/Log.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Events.Internal;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Events.Internal"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Debug, "Registering Event Type {EventType} with Alias {Alias}")]
+    internal static partial void Registering(this ILogger logger, EventTypeId eventType, EventTypeAlias alias);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Failed to register Event Type {EventType} with Alias {Alias} because {Reason}")]
+    internal static partial void FailedToRegister(this ILogger logger, EventTypeId eventType, EventTypeAlias alias, string reason);
+    
+    [LoggerMessage(0, LogLevel.Warning, "An error occurred while registering Event Type {EventType} with Alias {Alias}")]
+    internal static partial void ErrorWhileRegistering(this ILogger logger, EventTypeId eventType, EventTypeAlias alias, Exception exception);
+}

--- a/Source/Events/Store/AggregateEventCommitter.cs
+++ b/Source/Events/Store/AggregateEventCommitter.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using Dolittle.SDK.Events.Store.Builders;
-using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Events.Store;
 
@@ -14,25 +13,21 @@ public class AggregateEventCommitter : ICommitAggregateEvents
 {
     readonly Internal.ICommitAggregateEvents _aggregateEvents;
     readonly IEventTypes _eventTypes;
-    readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AggregateEventCommitter"/> class.
     /// </summary>
     /// <param name="aggregateEvents">The <see cref="Internal.ICommitAggregateEvents" />.</param>
     /// <param name="eventTypes">The <see cref="IEventTypes" />.</param>
-    /// <param name="logger">The <see cref="ILogger" />.</param>
     public AggregateEventCommitter(
         Internal.ICommitAggregateEvents aggregateEvents,
-        IEventTypes eventTypes,
-        ILogger logger)
+        IEventTypes eventTypes)
     {
         _aggregateEvents = aggregateEvents;
         _eventTypes = eventTypes;
-        _logger = logger;
     }
 
     /// <inheritdoc/>
     public CommitForAggregateBuilder ForAggregate(AggregateRootId aggregateRootId, CancellationToken cancellationToken = default)
-        => new(_aggregateEvents, _eventTypes, aggregateRootId, _logger);
+        => new(_aggregateEvents, _eventTypes, aggregateRootId);
 }

--- a/Source/Events/Store/Builders/CommitForAggregateBuilder.cs
+++ b/Source/Events/Store/Builders/CommitForAggregateBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Dolittle.SDK.Events.Builders;
-using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Events.Store.Builders;
 
@@ -14,7 +13,6 @@ public class CommitForAggregateBuilder
     readonly Internal.ICommitAggregateEvents _aggregateEvents;
     readonly IEventTypes _eventTypes;
     readonly AggregateRootId _aggregateRootId;
-    readonly ILogger _logger;
     CommitForAggregateWithEventSourceBuilder _builder;
 
     /// <summary>
@@ -23,17 +21,14 @@ public class CommitForAggregateBuilder
     /// <param name="aggregateEvents">The <see cref="Internal.ICommitAggregateEvents" />.</param>
     /// <param name="eventTypes">The <see cref="IEventTypes" />.</param>
     /// <param name="aggregateRootId">The <see cref="AggregateRootId" />.</param>
-    /// <param name="logger">The <see cref="ILogger" />.</param>
     public CommitForAggregateBuilder(
         Internal.ICommitAggregateEvents aggregateEvents,
         IEventTypes eventTypes,
-        AggregateRootId aggregateRootId,
-        ILogger logger)
+        AggregateRootId aggregateRootId)
     {
         _aggregateEvents = aggregateEvents;
         _eventTypes = eventTypes;
         _aggregateRootId = aggregateRootId;
-        _logger = logger;
     }
 
     /// <summary>
@@ -44,7 +39,7 @@ public class CommitForAggregateBuilder
     public CommitForAggregateWithEventSourceBuilder WithEventSource(EventSourceId eventSourceId)
     {
         if (_builder != default) throw new EventBuilderMethodAlreadyCalled("WithEventSource");
-        _builder = new CommitForAggregateWithEventSourceBuilder(_aggregateEvents, _eventTypes, _aggregateRootId, eventSourceId, _logger);
+        _builder = new CommitForAggregateWithEventSourceBuilder(_aggregateEvents, _eventTypes, _aggregateRootId, eventSourceId);
         return _builder;
     }
 }

--- a/Source/Events/Store/Builders/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.cs
+++ b/Source/Events/Store/Builders/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.SDK.Events.Builders;
-using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Events.Store.Builders;
 
@@ -19,7 +18,6 @@ public class CommitForAggregateWithEventSourceAndExpectedVersionBuilder
     readonly AggregateRootId _aggregateRootId;
     readonly EventSourceId _eventSourceId;
     readonly AggregateRootVersion _expectedVersion;
-    readonly ILogger _logger;
     UncommittedAggregateEventsBuilder _builder;
 
     /// <summary>
@@ -30,21 +28,18 @@ public class CommitForAggregateWithEventSourceAndExpectedVersionBuilder
     /// <param name="aggregateRootId">The <see cref="AggregateRootId" />.</param>
     /// <param name="eventSourceId">The <see cref="EventSourceId" />.</param>
     /// <param name="expectedVersion">The expected <see cref="AggregateRootVersion" />.</param>
-    /// <param name="logger">The <see cref="ILogger" />.</param>
     public CommitForAggregateWithEventSourceAndExpectedVersionBuilder(
         Internal.ICommitAggregateEvents aggregateEvents,
         IEventTypes eventTypes,
         AggregateRootId aggregateRootId,
         EventSourceId eventSourceId,
-        AggregateRootVersion expectedVersion,
-        ILogger logger)
+        AggregateRootVersion expectedVersion)
     {
         _aggregateEvents = aggregateEvents;
         _eventTypes = eventTypes;
         _aggregateRootId = aggregateRootId;
         _eventSourceId = eventSourceId;
         _expectedVersion = expectedVersion;
-        _logger = logger;
     }
 
     /// <summary>

--- a/Source/Events/Store/Builders/CommitForAggregateWithEventSourceBuilder.cs
+++ b/Source/Events/Store/Builders/CommitForAggregateWithEventSourceBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Dolittle.SDK.Events.Builders;
-using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Events.Store.Builders;
 
@@ -13,7 +12,6 @@ public class CommitForAggregateWithEventSourceBuilder
 {
     readonly AggregateRootId _aggregateRootId;
     readonly EventSourceId _eventSourceId;
-    readonly ILogger _logger;
     readonly Internal.ICommitAggregateEvents _aggregateEvents;
     readonly IEventTypes _eventTypes;
     CommitForAggregateWithEventSourceAndExpectedVersionBuilder _builder;
@@ -25,19 +23,16 @@ public class CommitForAggregateWithEventSourceBuilder
     /// <param name="eventTypes">The <see cref="IEventTypes" />.</param>
     /// <param name="aggregateRootId">The <see cref="AggregateRootId" />.</param>
     /// <param name="eventSourceId">The <see cref="EventSourceId" />.</param>
-    /// <param name="logger">The <see cref="ILogger" />.</param>
     public CommitForAggregateWithEventSourceBuilder(
         Internal.ICommitAggregateEvents aggregateEvents,
         IEventTypes eventTypes,
         AggregateRootId aggregateRootId,
-        EventSourceId eventSourceId,
-        ILogger logger)
+        EventSourceId eventSourceId)
     {
         _aggregateEvents = aggregateEvents;
         _eventTypes = eventTypes;
         _aggregateRootId = aggregateRootId;
         _eventSourceId = eventSourceId;
-        _logger = logger;
     }
 
     /// <summary>
@@ -53,8 +48,7 @@ public class CommitForAggregateWithEventSourceBuilder
             _eventTypes,
             _aggregateRootId,
             _eventSourceId,
-            expectedVersion,
-            _logger);
+            expectedVersion);
         return _builder;
     }
 }

--- a/Source/Events/Store/Builders/EventStoreBuilder.cs
+++ b/Source/Events/Store/Builders/EventStoreBuilder.cs
@@ -93,8 +93,7 @@ public class EventStoreBuilder : IEventStoreBuilder
                 _callContextResolver,
                 executionContext,
                 _loggerFactory.CreateLogger<Internal.AggregateEventCommitter>()),
-            _eventTypes,
-            _loggerFactory.CreateLogger<AggregateEventCommitter>());
+            _eventTypes);
 
     IFetchEventsForAggregate CreateEventsForAggregateFetcher(ExecutionContext executionContext)
         => new Internal.EventsForAggregateFetcher(

--- a/Source/Events/Store/Internal/AggregateEventCommitter.cs
+++ b/Source/Events/Store/Internal/AggregateEventCommitter.cs
@@ -52,16 +52,14 @@ public class AggregateEventCommitter : ICommitAggregateEvents
     /// <inheritdoc/>
     public async Task<CommittedAggregateEvents> CommitForAggregate(UncommittedAggregateEvents uncommittedAggregateEvents, CancellationToken cancellationToken = default)
     {
-        Log.CommittingAggregateEvents(
-            _logger,
-            uncommittedAggregateEvents.Count,
+        _logger.CommittingAggregateEvents(uncommittedAggregateEvents.Count,
             uncommittedAggregateEvents.AggregateRoot,
             uncommittedAggregateEvents.EventSource,
             uncommittedAggregateEvents.ExpectedAggregateRootVersion);
 
         if (!_toProtobuf.TryConvert(uncommittedAggregateEvents, out var protobufEvents, out var error))
         {
-            Log.UncommittedAggregateEventsCouldNotBeConverted(_logger, error);
+            _logger.UncommittedAggregateEventsCouldNotBeConverted(error);
             throw error;
         }
 
@@ -77,7 +75,7 @@ public class AggregateEventCommitter : ICommitAggregateEvents
         {
             return committedAggregateEvents;
         }
-        Log.CommittedAggregateEventsCouldNotBeConverted(_logger, error);
+        _logger.CommittedAggregateEventsCouldNotBeConverted(error);
         throw error;
 
     }

--- a/Source/Events/Store/Internal/EventCommitter.cs
+++ b/Source/Events/Store/Internal/EventCommitter.cs
@@ -52,11 +52,11 @@ public class EventCommitter : ICommitEvents
     /// <inheritdoc/>
     public async Task<CommittedEvents> Commit(UncommittedEvents uncommittedEvents, CancellationToken cancellationToken = default)
     {
-        Log.CommittingEvents(_logger, uncommittedEvents.Count);
+        _logger.CommittingEvents(uncommittedEvents.Count);
 
         if (!_toProtobuf.TryConvert(uncommittedEvents, out var protobufEvents, out var error))
         {
-            Log.UncommittedEventsCouldNotBeConverted(_logger, error);
+            _logger.UncommittedEventsCouldNotBeConverted(error);
             throw error;
         }
 
@@ -73,7 +73,7 @@ public class EventCommitter : ICommitEvents
         {
             return committedEvents;
         }
-        Log.CommittedEventsCouldNotBeConverted(_logger, error);
+        _logger.CommittedEventsCouldNotBeConverted(error);
         throw error;
     }
 }

--- a/Source/Events/Store/Internal/EventsForAggregateFetcher.cs
+++ b/Source/Events/Store/Internal/EventsForAggregateFetcher.cs
@@ -52,7 +52,7 @@ public class EventsForAggregateFetcher : IFetchEventsForAggregate
         EventSourceId eventSourceId,
         CancellationToken cancellationToken = default)
     {
-        Log.FetchingEventsForAggregate(_logger, aggregateRootId, eventSourceId);
+        _logger.FetchingEventsForAggregate(aggregateRootId, eventSourceId);
         var request = new Runtime.Events.Contracts.FetchForAggregateRequest
         {
             CallContext = _callContextResolver.ResolveFrom(_executionContext),
@@ -70,7 +70,7 @@ public class EventsForAggregateFetcher : IFetchEventsForAggregate
         {
             return committedAggregateEvents;
         }
-        Log.FetchedEventsForAggregateCouldNotBeConverted(_logger, error);
+        _logger.FetchedEventsForAggregateCouldNotBeConverted(error);
         throw error;
 
     }

--- a/Source/Events/Store/Internal/Log.cs
+++ b/Source/Events/Store/Internal/Log.cs
@@ -6,29 +6,32 @@ using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Events.Store.Internal;
 
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Events.Store.Internal"/>.
+/// </summary>
 static partial class Log
 {
     [LoggerMessage(0, LogLevel.Debug, "Committing {NumberOfEvents} events for aggregate root type {AggregateRoot} and id {EventSource} with expected version {ExpectedVersion}")]
-    internal static partial void CommittingAggregateEvents(ILogger logger, int numberOfEvents, AggregateRootId aggregateRoot, EventSourceId eventSource, AggregateRootVersion expectedVersion);
+    internal static partial void CommittingAggregateEvents(this ILogger logger, int numberOfEvents, AggregateRootId aggregateRoot, EventSourceId eventSource, AggregateRootVersion expectedVersion);
     
     [LoggerMessage(0, LogLevel.Debug, "Committing {NumberOfEvents} events")]
-    internal static partial void CommittingEvents(ILogger logger, int numberOfEvents);
+    internal static partial void CommittingEvents(this ILogger logger, int numberOfEvents);
     
     [LoggerMessage(0, LogLevel.Error, "Could not convert UncommittedAggregateEvents to Protobuf.")]
-    internal static partial void UncommittedAggregateEventsCouldNotBeConverted(ILogger logger, Exception ex);
+    internal static partial void UncommittedAggregateEventsCouldNotBeConverted(this ILogger logger, Exception ex);
     
     [LoggerMessage(0, LogLevel.Error, "Could not convert UncommittedEvents to Protobuf.")]
-    internal static partial void UncommittedEventsCouldNotBeConverted(ILogger logger, Exception ex);
+    internal static partial void UncommittedEventsCouldNotBeConverted(this ILogger logger, Exception ex);
     
     [LoggerMessage(0, LogLevel.Error, "The Runtime acknowledges that the events have been committed, but the returned CommittedAggregateEvents could not be converted.")]
-    internal static partial void CommittedAggregateEventsCouldNotBeConverted(ILogger logger, Exception ex);
+    internal static partial void CommittedAggregateEventsCouldNotBeConverted(this ILogger logger, Exception ex);
     
     [LoggerMessage(0, LogLevel.Error, "The Runtime acknowledges that the events have been committed, but the returned CommittedEvents could not be converted.")]
-    internal static partial void CommittedEventsCouldNotBeConverted(ILogger logger, Exception ex);
+    internal static partial void CommittedEventsCouldNotBeConverted(this ILogger logger, Exception ex);
     
     [LoggerMessage(0, LogLevel.Debug, "Fetching events for aggregate root {AggregateRoot} and event source {EventSource}")]
-    internal static partial void FetchingEventsForAggregate(ILogger logger, AggregateRootId aggregateRoot, EventSourceId eventSource);
+    internal static partial void FetchingEventsForAggregate(this ILogger logger, AggregateRootId aggregateRoot, EventSourceId eventSource);
     
     [LoggerMessage(0, LogLevel.Error, "Could not convert CommittedAggregateEvents to SDK.")]
-    internal static partial void FetchedEventsForAggregateCouldNotBeConverted(ILogger logger, Exception ex);
+    internal static partial void FetchedEventsForAggregateCouldNotBeConverted(this ILogger logger, Exception ex);
 }

--- a/Source/Projections/Builder/ConventionProjectionBuilder.cs
+++ b/Source/Projections/Builder/ConventionProjectionBuilder.cs
@@ -77,7 +77,10 @@ public class ConventionProjectionBuilder<TProjection> : ICanTryBuildProjection
             return false;
         }
         
-        projection = new Projection<TProjection>(_decorator.Identifier, _decorator.Scope, eventTypesToMethods, new ProjectionCopies(copyToMongoDB));
+        projection = _decorator.HasAlias
+            ? new Projection<TProjection>(_decorator.Identifier, _decorator.Alias, _decorator.Scope, eventTypesToMethods, new ProjectionCopies(copyToMongoDB))
+            : new Projection<TProjection>(_decorator.Identifier, _projectionType.Name, _decorator.Scope, eventTypesToMethods, new ProjectionCopies(copyToMongoDB));
+        
         return true;
     }
     

--- a/Source/Projections/Builder/Copies/MongoDB/IBuildPropertyConversionsFromMongoDBConvertToAttributes.cs
+++ b/Source/Projections/Builder/Copies/MongoDB/IBuildPropertyConversionsFromMongoDBConvertToAttributes.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Dolittle.SDK.Projections.Copies.MongoDB;
-
 namespace Dolittle.SDK.Projections.Builder.Copies.MongoDB;
 
 /// <summary>

--- a/Source/Projections/Builder/Copies/MongoDB/IBuildPropertyConversionsFromMongoDBConvertToAttributes.cs
+++ b/Source/Projections/Builder/Copies/MongoDB/IBuildPropertyConversionsFromMongoDBConvertToAttributes.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Dolittle.SDK.Projections.Copies.MongoDB;
+
 namespace Dolittle.SDK.Projections.Builder.Copies.MongoDB;
 
 /// <summary>
-/// Defines a <see cref="ICanBuildPropertyConversionsFromReadModel"/> that builds property conversions from projection properties marked with <see cref="MongoDBConvertToAttribute"/>. 
+/// Defines a <see cref="ICanBuildPropertyConversionsFromReadModel"/> that builds property conversions from projection properties marked with <see cref="ConvertToMongoDBAttribute"/>. 
 /// </summary>
 public interface IBuildPropertyConversionsFromMongoDBConvertToAttributes : ICanBuildPropertyConversionsFromReadModel
 {

--- a/Source/Projections/Builder/Copies/MongoDB/Internal/IMongoDBCopyDefinitionFromReadModelBuilder.cs
+++ b/Source/Projections/Builder/Copies/MongoDB/Internal/IMongoDBCopyDefinitionFromReadModelBuilder.cs
@@ -3,11 +3,12 @@
 
 using System;
 using Dolittle.SDK.Common.ClientSetup;
+using Dolittle.SDK.Projections.Copies.MongoDB;
 
 namespace Dolittle.SDK.Projections.Builder.Copies.MongoDB.Internal;
 
 /// <summary>
-/// Defines a system that builds a <see cref="MongoDBCopyDefinitionFromReadModelBuilder{TReadModel}"/> from a projection read model <see cref="Type"/>. 
+/// Defines a system that builds a <see cref="ProjectionCopyToMongoDB"/> from a projection read model <see cref="Type"/>. 
 /// </summary>
 public interface IMongoDBCopyDefinitionFromReadModelBuilder
 {

--- a/Source/Projections/Builder/Copies/MongoDB/ProjectionCopyToMongoDBBuilder.cs
+++ b/Source/Projections/Builder/Copies/MongoDB/ProjectionCopyToMongoDBBuilder.cs
@@ -24,9 +24,9 @@ public class ProjectionCopyToMongoDBBuilder<TReadModel> : Internal.IProjectionCo
     readonly IBuildPropertyConversionsFromBsonClassMap _conversionsFromBSONClassMap;
     readonly IMongoDBCopyDefinitionFromReadModelBuilder _mongoDbCopyFromReadModelBuilder;
     readonly IResolvePropertyPath _propertyPathResolver;
+    readonly Dictionary<PropertyPath, Conversion> _explicitConversions = new();
     MongoDBCopyCollectionName _collectionName;
     bool _withoutDefaultConversions;
-    Dictionary<PropertyPath, Conversion> _explicitConversions = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProjectionCopyToMongoDBBuilder{TReadMOdel}"/> class.

--- a/Source/Projections/Builder/IProjectionBuilderForReadModel.cs
+++ b/Source/Projections/Builder/IProjectionBuilderForReadModel.cs
@@ -99,10 +99,16 @@ public interface IProjectionBuilderForReadModel<TReadModel>
     IProjectionBuilderForReadModel<TReadModel> On(EventTypeId eventTypeId, Generation eventTypeGeneration, KeySelectorSignature selectorCallback, SyncProjectionSignature<TReadModel> method);
 
     /// <summary>
+    /// Defines the projection to have a specific <see cref="ProjectionAlias" />.
+    /// </summary>
+    /// <param name="alias">The <see cref="ProjectionAlias" />.</param>
+    /// <returns>The builder for continuation.</returns>
+    IProjectionBuilderForReadModel<TReadModel> WithAlias(ProjectionAlias alias);
+    
+    /// <summary>
     /// Adds the copy to MongoDB definition.
     /// </summary>
     /// <param name="callback">The optonal callback for building the MongoDB copy definition.</param>
     /// <returns>The builder for continuation.</returns>
     IProjectionBuilderForReadModel<TReadModel> CopyToMongoDB(Action<IProjectionCopyToMongoDBBuilder<TReadModel>> callback = default);
-
 }

--- a/Source/Projections/Builder/ProjectionBuilderForReadModel.cs
+++ b/Source/Projections/Builder/ProjectionBuilderForReadModel.cs
@@ -22,6 +22,7 @@ public class ProjectionBuilderForReadModel<TReadModel> : IProjectionBuilderForRe
 {
     readonly IList<IProjectionMethod<TReadModel>> _methods = new List<IProjectionMethod<TReadModel>>();
     readonly ProjectionId _projectionId;
+    ProjectionAlias _alias;
     ScopeId _scopeId;
     readonly IModelBuilder _modelBuilder;
     readonly ProjectionBuilder _parentBuilder;
@@ -45,6 +46,7 @@ public class ProjectionBuilderForReadModel<TReadModel> : IProjectionBuilderForRe
         IProjectionCopyDefinitionBuilder<TReadModel> copyDefinitionBuilder)
     {
         _projectionId = projectionId;
+        _alias = typeof(TReadModel).Name;
         _scopeId = scopeId;
         _modelBuilder = modelBuilder;
         _parentBuilder = parentBuilder;
@@ -114,6 +116,13 @@ public class ProjectionBuilderForReadModel<TReadModel> : IProjectionBuilderForRe
         => On(new EventType(eventTypeId, eventTypeGeneration), selectorCallback, method);
 
     /// <inheritdoc />
+    public IProjectionBuilderForReadModel<TReadModel> WithAlias(ProjectionAlias alias)
+    {
+        _alias = alias;
+        return this;
+    }
+
+    /// <inheritdoc />
     public IProjectionBuilderForReadModel<TReadModel> CopyToMongoDB(Action<IProjectionCopyToMongoDBBuilder<TReadModel>> callback = default)
     {
         _projectionCopyDefinitionBuilder.CopyToMongoDB(callback);
@@ -139,7 +148,7 @@ public class ProjectionBuilderForReadModel<TReadModel> : IProjectionBuilderForRe
 
         if (eventTypesToMethods.Any())
         {
-            projection = new Projection<TReadModel>(_projectionId, _scopeId, eventTypesToMethods, projectionCopies);
+            projection = new Projection<TReadModel>(_projectionId, _alias, _scopeId, eventTypesToMethods, projectionCopies);
             return true;
         }
         buildResults.AddFailure($"Failed to build projection {_projectionId}. No projection methods are configured for projection", "Handle an event by calling one of the On-methods on the projection builder");

--- a/Source/Projections/Builder/ProjectionsBuilder.cs
+++ b/Source/Projections/Builder/ProjectionsBuilder.cs
@@ -84,14 +84,14 @@ public class ProjectionsBuilder : IProjectionsBuilder
         => Activator.CreateInstance(
                 typeof(ConventionProjectionBuilder<>).MakeGenericType(readModelType),
                 decorator,
-                CreateForMethodForReadModel(readModelType).Invoke(_copyToMongoDbBuilderFactory, new object[] {}))
+                CreateForMethodForReadModel(readModelType).Invoke(_copyToMongoDbBuilderFactory, Array.Empty<object>()))
             as ICanTryBuildProjection;
     
     
     static MethodInfo CreateForMethodForReadModel(Type readModelType)
         => typeof(IProjectionCopyToMongoDBBuilderFactory).GetMethod(
                 nameof(IProjectionCopyToMongoDBBuilderFactory.CreateFor),
-                new Type[] {})
+                Array.Empty<Type>())
             ?.MakeGenericMethod(readModelType);
     
 

--- a/Source/Projections/Builder/UnregisteredProjections.cs
+++ b/Source/Projections/Builder/UnregisteredProjections.cs
@@ -10,14 +10,12 @@ using Dolittle.SDK.DependencyInversion;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Events.Processing;
 using Dolittle.SDK.Events.Processing.Internal;
-using Dolittle.SDK.Projections.Copies.MongoDB;
 using Dolittle.SDK.Projections.Internal;
 using Dolittle.SDK.Projections.Store;
 using Dolittle.SDK.Projections.Store.Converters;
 using Dolittle.SDK.Tenancy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 
 namespace Dolittle.SDK.Projections.Builder;

--- a/Source/Projections/Copies/MongoDB/MongoDBCopyCollectionName.cs
+++ b/Source/Projections/Copies/MongoDB/MongoDBCopyCollectionName.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Reflection;
 using Dolittle.SDK.Common;
 using Dolittle.SDK.Concepts;
 
@@ -31,7 +32,7 @@ public record MongoDBCopyCollectionName(string Value) : ConceptAs<string>(Value)
     /// Try get the <see cref="MongoDBCopyCollectionName"/> from a <see cref="Type"/>.
     /// </summary>
     /// <typeparam name="TSchema">The <see cref="Type"/> of the projection.</typeparam>
-    /// <returns>The <see cref="MongoDBCopyCollectionName"/> derived from the <see cref="CopyProjectionToMongoDBAttribute"/> or the <see cref="Type.Name"/>.</returns>
+    /// <returns>The <see cref="MongoDBCopyCollectionName"/> derived from the <see cref="CopyProjectionToMongoDBAttribute"/> or the <see cref="MemberInfo.Name"/>.</returns>
     public static MongoDBCopyCollectionName GetFrom<TSchema>()
         where TSchema : class
         => GetFrom(typeof(TSchema));
@@ -40,7 +41,7 @@ public record MongoDBCopyCollectionName(string Value) : ConceptAs<string>(Value)
     /// Try get the <see cref="MongoDBCopyCollectionName"/> from a <see cref="Type"/>.
     /// </summary>
     /// <param name="type">The <see cref="Type"/> to get the <see cref="MongoDBCopyCollectionName"/> from.</param>
-    /// <returns>The <see cref="MongoDBCopyCollectionName"/> derived from the <see cref="CopyProjectionToMongoDBAttribute"/> or the <see cref="Type.Name"/>.</returns>
+    /// <returns>The <see cref="MongoDBCopyCollectionName"/> derived from the <see cref="CopyProjectionToMongoDBAttribute"/> or the <see cref="MemberInfo.Name"/>.</returns>
     public static MongoDBCopyCollectionName GetFrom(Type type)
     {
         if (!type.TryGetDecorator<CopyProjectionToMongoDBAttribute>(out var decorator) || string.IsNullOrEmpty(decorator.CollectionName))

--- a/Source/Projections/IProjection.cs
+++ b/Source/Projections/IProjection.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Projections.Copies;
 
@@ -34,34 +32,19 @@ public interface IProjection
     /// Gets the <see cref="ProjectionCopies"/>.
     /// </summary>
     ProjectionCopies Copies { get; }
+    
+    /// <summary>
+    /// Gets the alias of the projection.
+    /// </summary>
+    ProjectionAlias Alias { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the projection has an alias or not.
+    /// </summary>
+    bool HasAlias { get; }
 
     /// <summary>
     /// Gets the event types identified by its artifact that is handled by this event handler.
     /// </summary>
     IEnumerable<EventSelector> Events { get; }
-}
-
-
-/// <summary>
-/// Defines a projection.
-/// </summary>
-/// <typeparam name="TReadModel">The type of the read model.</typeparam>
-public interface IProjection<TReadModel> : IProjection
-    where TReadModel : class, new()
-{
-    /// <summary>
-    /// Gets the initial <typeparamref name="TReadModel"/> read model state.
-    /// </summary>
-    TReadModel InitialState { get; }
-
-    /// <summary>
-    /// Handle an event and update a read model.
-    /// </summary>
-    /// <param name="readModel">The read model to update.</param>
-    /// <param name="event">The event to handle.</param>
-    /// <param name="eventType">The artifact representing the event type.</param>
-    /// <param name="context">The context of the projection.</param>
-    /// <param name="cancellation">The <see cref="CancellationToken" /> used to cancel the processing of the request.</param>
-    /// <returns>A <see cref="Task"/> that, when resolved, returns a <see cref="ProjectionResult{TReadModel}"/>.</returns>
-    Task<ProjectionResult<TReadModel>> On(TReadModel readModel, object @event, EventType eventType, ProjectionContext context, CancellationToken cancellation);
 }

--- a/Source/Projections/IProjection{TReadModel}.cs
+++ b/Source/Projections/IProjection{TReadModel}.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.SDK.Events;
+
+namespace Dolittle.SDK.Projections;
+
+/// <summary>
+/// Defines a projection.
+/// </summary>
+/// <typeparam name="TReadModel">The type of the read model.</typeparam>
+public interface IProjection<TReadModel> : IProjection
+    where TReadModel : class, new()
+{
+    /// <summary>
+    /// Gets the initial <typeparamref name="TReadModel"/> read model state.
+    /// </summary>
+    TReadModel InitialState { get; }
+
+    /// <summary>
+    /// Handle an event and update a read model.
+    /// </summary>
+    /// <param name="readModel">The read model to update.</param>
+    /// <param name="event">The event to handle.</param>
+    /// <param name="eventType">The artifact representing the event type.</param>
+    /// <param name="context">The context of the projection.</param>
+    /// <param name="cancellation">The <see cref="CancellationToken" /> used to cancel the processing of the request.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns a <see cref="ProjectionResult{TReadModel}"/>.</returns>
+    Task<ProjectionResult<TReadModel>> On(TReadModel readModel, object @event, EventType eventType, ProjectionContext context, CancellationToken cancellation);
+}

--- a/Source/Projections/Internal/ProjectionsProcessor.cs
+++ b/Source/Projections/Internal/ProjectionsProcessor.cs
@@ -59,6 +59,11 @@ public class ProjectionsProcessor<TReadModel> : EventProcessor<ProjectionId, Pro
                 InitialState = JsonConvert.SerializeObject(_projection.InitialState, Formatting.None),
                 Copies = _projection.Copies.ToProtobuf()
             };
+            if (_projection.HasAlias)
+            {
+                registrationRequest.Alias = _projection.Alias.Value;
+            }
+            
             registrationRequest.Events.AddRange(_projection.Events.Select(CreateProjectionEventSelector).ToArray());
 
             return registrationRequest;

--- a/Source/Projections/KeyFromEventOccurredAttribute.cs
+++ b/Source/Projections/KeyFromEventOccurredAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using Dolittle.SDK.Projections.Builder;
 

--- a/Source/Projections/Projection.cs
+++ b/Source/Projections/Projection.cs
@@ -42,6 +42,26 @@ public class Projection<TReadModel> : IProjection<TReadModel>
         Copies = copies;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Projection{TReadModel}"/> class.
+    /// </summary>
+    /// <param name="identifier">The <see cref="ProjectionId" />.</param>
+    /// <param name="alias">The <see cref="ProjectionAlias" />.</param>
+    /// <param name="scopeId">The <see cref="ScopeId" />.</param>
+    /// <param name="onMethods">The on methods by <see cref="EventType" />.</param>
+    /// <param name="copies">The <see cref="ProjectionCopies"/>.</param>
+    public Projection(
+        ProjectionId identifier,
+        ProjectionAlias alias,
+        ScopeId scopeId,
+        IDictionary<EventType, IProjectionMethod<TReadModel>> onMethods,
+        ProjectionCopies copies)
+        :this(identifier, scopeId, onMethods, copies)
+    {
+        Alias = alias;
+        HasAlias = true;
+    }
+
     /// <inheritdoc />
     public Type ProjectionType { get; }
 
@@ -59,6 +79,12 @@ public class Projection<TReadModel> : IProjection<TReadModel>
 
     /// <inheritdoc />
     public ProjectionCopies Copies { get; }
+
+    /// <inheritdoc />
+    public ProjectionAlias Alias { get; }
+
+    /// <inheritdoc />
+    public bool HasAlias { get; }
 
     /// <inheritdoc/>
     public async Task<ProjectionResult<TReadModel>> On(TReadModel readModel, object @event, EventType eventType, ProjectionContext context, CancellationToken cancellation)

--- a/Source/Projections/ProjectionAlias.cs
+++ b/Source/Projections/ProjectionAlias.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.SDK.Concepts;
+
+namespace Dolittle.SDK.Projections;
+
+/// <summary>
+/// Represents the concept of an alias for a Projection.
+/// </summary>
+/// <param name="Value"></param>
+public record ProjectionAlias(string Value) : ConceptAs<string>(Value)
+{
+    /// <summary>
+    /// Implicitly converts from a <see cref="string"/> to an <see cref="ProjectionAlias"/>.
+    /// </summary>
+    /// <param name="alias">The <see cref="string"/> representation.</param>
+    /// <returns>The converted <see cref="ProjectionAlias"/>.</returns>
+    public static implicit operator ProjectionAlias(string alias) => new(alias);
+}

--- a/Source/Projections/ProjectionAttribute.cs
+++ b/Source/Projections/ProjectionAttribute.cs
@@ -18,10 +18,16 @@ public class ProjectionAttribute : Attribute, IDecoratedTypeDecorator<Projection
     /// </summary>
     /// <param name="projectionId">The unique identifier of the event handler.</param>
     /// <param name="inScope">The scope that the event handler handles events in.</param>
-    public ProjectionAttribute(string projectionId, string inScope = default)
+    /// <param name="alias">The alias for the projection.</param>
+    public ProjectionAttribute(string projectionId, string inScope = default, string alias = default)
     {
         Identifier = Guid.Parse(projectionId);
         Scope = inScope ?? ScopeId.Default;
+        if (alias != default)
+        {
+            Alias = alias;
+            HasAlias = true;
+        }
     }
 
     /// <summary>
@@ -33,6 +39,16 @@ public class ProjectionAttribute : Attribute, IDecoratedTypeDecorator<Projection
     /// Gets the <see cref="ScopeId" />.
     /// </summary>
     public ScopeId Scope { get; }
+
+    /// <summary>
+    /// Gets the <see cref="ProjectionAlias"/>.
+    /// </summary>
+    public ProjectionAlias Alias { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this event handler has an alias.
+    /// </summary>
+    public bool HasAlias { get; }
 
     /// <inheritdoc />
     public ProjectionModelId GetIdentifier() => new(Identifier, Scope);

--- a/Source/Projections/StaticKeyAttribute.cs
+++ b/Source/Projections/StaticKeyAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using Dolittle.SDK.Projections.Builder;
 

--- a/Source/Projections/Store/Log.cs
+++ b/Source/Projections/Store/Log.cs
@@ -8,23 +8,26 @@ using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Projections.Store;
 
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Projections.Store"/>.
+/// </summary>
 static partial class Log
 {
     [LoggerMessage(0, LogLevel.Debug, "Getting read model of projection {Projection} of type {ProjectionType} in scope {Scope} with key {Key}")]
-    internal static partial void GettingOneProjection(ILogger logger, Key key, ProjectionId projection, Type projectionType, ScopeId scope);
+    internal static partial void GettingOneProjection(this ILogger logger, Key key, ProjectionId projection, Type projectionType, ScopeId scope);
     
     [LoggerMessage(0, LogLevel.Debug, "Getting the state of projection {Projection} of type {ProjectionType} in scope {Scope} with key {Key}")]
-    internal static partial void GettingOneProjectionState(ILogger logger, Key key, ProjectionId projection, Type projectionType, ScopeId scope);
+    internal static partial void GettingOneProjectionState(this ILogger logger, Key key, ProjectionId projection, Type projectionType, ScopeId scope);
 
     [LoggerMessage(0, LogLevel.Debug, "Getting all read models from projection {Projection} of type {ProjectionType} in scope {Scope}")]
-    internal static partial void GettingAllProjections(ILogger logger, ProjectionId projection, Type projectionType, ScopeId scope);
+    internal static partial void GettingAllProjections(this ILogger logger, ProjectionId projection, Type projectionType, ScopeId scope);
     
     [LoggerMessage(0, LogLevel.Trace, "Received batch number {BatchNumber} consisting of {NumProjections} projection read models")]
-    internal static partial void ProcessingProjectionsInBatch(ILogger logger, int batchNumber, int numProjections);
+    internal static partial void ProcessingProjectionsInBatch(this ILogger logger, int batchNumber, int numProjections);
     
     [LoggerMessage(0, LogLevel.Error, "Could not convert projection read model to {ProjectionType}. State: {State}")]
-    internal static partial void FailedToConvertProjectionState(ILogger logger, Exception exception, string state, Type projectionType);
+    internal static partial void FailedToConvertProjectionState(this ILogger logger, Exception exception, string state, Type projectionType);
     
     [LoggerMessage(0, LogLevel.Error, "Could not convert projection read models to {ProjectionType}. States: {State}")]
-    internal static partial void FailedToConvertProjectionStates(ILogger logger, Exception exception, IEnumerable<string> state, Type projectionType);
+    internal static partial void FailedToConvertProjectionStates(this ILogger logger, Exception exception, IEnumerable<string> state, Type projectionType);
 }

--- a/Source/Projections/Store/Log.cs
+++ b/Source/Projections/Store/Log.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using Dolittle.SDK.Events;
 using Microsoft.Extensions.Logging;
 
@@ -25,9 +24,6 @@ static partial class Log
     [LoggerMessage(0, LogLevel.Trace, "Received batch number {BatchNumber} consisting of {NumProjections} projection read models")]
     internal static partial void ProcessingProjectionsInBatch(this ILogger logger, int batchNumber, int numProjections);
     
-    [LoggerMessage(0, LogLevel.Error, "Could not convert projection read model to {ProjectionType}. State: {State}")]
-    internal static partial void FailedToConvertProjectionState(this ILogger logger, Exception exception, string state, Type projectionType);
-    
-    [LoggerMessage(0, LogLevel.Error, "Could not convert projection read models to {ProjectionType}. States: {State}")]
-    internal static partial void FailedToConvertProjectionStates(this ILogger logger, Exception exception, IEnumerable<string> state, Type projectionType);
+    [LoggerMessage(0, LogLevel.Error, "Could not convert projection read model to {ProjectionType}")]
+    internal static partial void FailedToConvertProjectionState(this ILogger logger, Type projectionType, Exception exception);
 }

--- a/Source/Projections/Store/ProjectionStore.cs
+++ b/Source/Projections/Store/ProjectionStore.cs
@@ -175,7 +175,7 @@ public class ProjectionStore : IProjectionStore
 
             if (!_toSDK.TryConvert<TReadModel>(response.States, out var states, out var error))
             {
-                _logger.FailedToConvertProjectionStates(error, response.States.Select(_ => _.State), typeof(TReadModel));
+                _logger.FailedToConvertProjectionState(typeof(TReadModel), error);
                 throw error;
             }
             foreach (var (key, value) in states.ToDictionary(_ => _.Key))
@@ -207,7 +207,7 @@ public class ProjectionStore : IProjectionStore
             ThrowIfIncorrectCurrentState(key, projectionId, state);
             return state;
         }
-        _logger.FailedToConvertProjectionState(error, response.State.State, typeof(TReadModel));
+        _logger.FailedToConvertProjectionState(typeof(TReadModel), error);
         throw error;
     }
     static void ThrowIfIncorrectCurrentState<TReadModel>(Key key, ProjectionId projectionId, CurrentState<TReadModel> state)

--- a/Source/Projections/Store/ProjectionStore.cs
+++ b/Source/Projections/Store/ProjectionStore.cs
@@ -114,7 +114,7 @@ public class ProjectionStore : IProjectionStore
     public Task<CurrentState<TReadModel>> GetState<TReadModel>(Key key, ProjectionId projectionId, ScopeId scopeId, CancellationToken cancellation = default)
         where TReadModel : class, new()
     {
-        Log.GettingOneProjectionState(_logger, key, projectionId, typeof(TReadModel), scopeId);
+        _logger.GettingOneProjectionState(key, projectionId, typeof(TReadModel), scopeId);
         return GetStateInternal<TReadModel>(
             key,
             projectionId,
@@ -126,7 +126,7 @@ public class ProjectionStore : IProjectionStore
     public Task<TReadModel> Get<TReadModel>(Key key, ProjectionId projectionId, ScopeId scopeId, CancellationToken cancellation = default)
         where TReadModel : class, new()
     {
-        Log.GettingOneProjection(_logger, key, projectionId, typeof(TReadModel), scopeId);
+        _logger.GettingOneProjection(key, projectionId, typeof(TReadModel), scopeId);
         return GetStateInternal<TReadModel>(
             key,
             projectionId,
@@ -159,9 +159,7 @@ public class ProjectionStore : IProjectionStore
     public async Task<IEnumerable<TReadModel>> GetAll<TReadModel>(ProjectionId projectionId, ScopeId scopeId, CancellationToken cancellation = default)
         where TReadModel : class, new()
     {
-        Log.GettingAllProjections(
-            _logger,
-            projectionId,
+        _logger.GettingAllProjections(projectionId,
             typeof(TReadModel),
             scopeId);
 
@@ -173,11 +171,11 @@ public class ProjectionStore : IProjectionStore
                            cancellation))
         {
             response.Failure.ThrowIfFailureIsSet();
-            Log.ProcessingProjectionsInBatch(_logger, ++batchNumber, response.States.Count);
+            _logger.ProcessingProjectionsInBatch(++batchNumber, response.States.Count);
 
             if (!_toSDK.TryConvert<TReadModel>(response.States, out var states, out var error))
             {
-                Log.FailedToConvertProjectionStates(_logger, error, response.States.Select(_ => _.State), typeof(TReadModel));
+                _logger.FailedToConvertProjectionStates(error, response.States.Select(_ => _.State), typeof(TReadModel));
                 throw error;
             }
             foreach (var (key, value) in states.ToDictionary(_ => _.Key))
@@ -209,7 +207,7 @@ public class ProjectionStore : IProjectionStore
             ThrowIfIncorrectCurrentState(key, projectionId, state);
             return state;
         }
-        Log.FailedToConvertProjectionState(_logger, error, response.State.State, typeof(TReadModel));
+        _logger.FailedToConvertProjectionState(error, response.State.State, typeof(TReadModel));
         throw error;
     }
     static void ThrowIfIncorrectCurrentState<TReadModel>(Key key, ProjectionId projectionId, CurrentState<TReadModel> state)

--- a/Source/Resources/Internal/Log.cs
+++ b/Source/Resources/Internal/Log.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Tenancy;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Resources.Internal;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Resources.Internal"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Debug, "Getting {ResourceName} resource for tenant {Tenant}")]
+    internal static partial void GettingResource(this ILogger logger, ResourceName resourceName, TenantId tenant);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Failed getting {ResourceName} resource for tenant {Tenant} because {Reason}")]
+    internal static partial void FailedToGetResource(this ILogger logger, ResourceName resourceName, TenantId tenant, string reason);
+    
+    [LoggerMessage(0, LogLevel.Warning, "An error occured while getting {ResourceName} resource for tenant {Tenant}")]
+    internal static partial void ErrorWhileGettingResource(this ILogger logger, ResourceName resourceName, TenantId tenant, Exception exception);
+}

--- a/Source/Resources/Internal/ResourceCreator.cs
+++ b/Source/Resources/Internal/ResourceCreator.cs
@@ -56,7 +56,7 @@ public abstract class ResourceCreator<TResource, TRequest, TResponse>
     {
         try
         {
-            _logger.LogDebug("Getting {ResourceName} resource for tenant {Tenant}", _resource, tenant);
+            _logger.GettingResource(_resource, tenant);
             
             var executionContext = _executionContext.ForTenant(tenant);
             var callContext = new CallRequestContext {ExecutionContext = executionContext.ToProtobuf()};
@@ -66,7 +66,7 @@ public abstract class ResourceCreator<TResource, TRequest, TResponse>
 
             if (RequestFailed(response, out var failure))
             {
-                _logger.LogWarning("Failed getting {ResourceName} resource for tenant {Tenant} because {Reason}", _resource, tenant, failure.Reason);
+                _logger.FailedToGetResource(_resource, tenant, failure.Reason);
                 throw new FailedToGetResourceForTenant(_resource, tenant, failure.Reason);
             }
 
@@ -74,7 +74,7 @@ public abstract class ResourceCreator<TResource, TRequest, TResponse>
         }
         catch (Exception ex) when (ex is not FailedToGetResourceForTenant)
         {
-            _logger.LogWarning(ex, "Failed getting {ResourceName} resource for tenant {Tenant} because {Reason}", _resource, tenant);
+            _logger.ErrorWhileGettingResource(_resource, tenant, ex);
             throw new FailedToGetResourceForTenant(_resource, tenant, ex.Message);
         }
     }

--- a/Source/Resources/MongoDB/IMongoDBResource.cs
+++ b/Source/Resources/MongoDB/IMongoDBResource.cs
@@ -12,7 +12,7 @@ namespace Dolittle.SDK.Resources.MongoDB;
 public interface IMongoDBResource
 {
     /// <summary>
-    /// Gets the <see cref="IMongoDatabase"/> that is configured for this <see cref="IResource"/>.
+    /// Gets the <see cref="IMongoDatabase"/> that is configured for this <see cref="IMongoDBResource"/>.
     /// </summary>
     /// <param name="databaseSettingsCallback">The <see cref="Action{T}"/> callback for creating <see cref="MongoDatabaseSettings"/> used to create the <see cref="IMongoDatabase"/>.</param>
     /// <returns>An <see cref="IMongoDatabase"/>.</returns>

--- a/Source/Resources/ResourceName.cs
+++ b/Source/Resources/ResourceName.cs
@@ -6,13 +6,13 @@ using Dolittle.SDK.Concepts;
 namespace Dolittle.SDK.Resources;
 
 /// <summary>
-/// Represents the name of an <see cref="IResource" />.
+/// Represents the name of a resource.
 /// </summary>
 public record ResourceName(string Value) : ConceptAs<string>(Value)
 {
     /// <summary>
     /// Implicitly convert from a <see cref="string"/> to a <see cref="ResourceName"/>.
     /// </summary>
-    /// <param name="name">ResourceName as <see cref="string"/>.</param>
+    /// <param name="name">Resource name as <see cref="string"/>.</param>
     public static implicit operator ResourceName(string name) => new(name);
 }

--- a/Source/SDK/Builders/Log.cs
+++ b/Source/SDK/Builders/Log.cs
@@ -9,11 +9,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Builders;
 
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Builders"/>.
+/// </summary>
 static partial class Log
 {
-    [LoggerMessage(0, LogLevel.Debug, "Retry attempt {RetryCount} processing subscription to events in {Timeout}ms () from {ProducerMicroservice} in {ProducerTenant} in {ProducerStream} in {ProducerPartition} for {ConsumerTenant} into {ConsumerScope}")]
+    [LoggerMessage(0, LogLevel.Debug, "Retry attempt {RetryCount} processing subscription to events in {Timeout}ms from {ProducerMicroservice} in {ProducerTenant} in {ProducerStream} in {ProducerPartition} for {ConsumerTenant} into {ConsumerScope}")]
     internal static partial void RetryEventHorizonSubscription(
-        ILogger logger,
+        this ILogger logger,
         int retryCount,
         TimeSpan timeout,
         MicroserviceId producerMicroservice,

--- a/Source/SDK/Builders/SetupBuilder.cs
+++ b/Source/SDK/Builders/SetupBuilder.cs
@@ -152,8 +152,7 @@ public class SetupBuilder : ISetupBuilder
         {
             retryCount++;
             var timeout = TimeSpan.FromSeconds(5);
-            Log.RetryEventHorizonSubscription(
-                logger,
+            logger.RetryEventHorizonSubscription(
                 retryCount,
                 timeout,
                 subscription.ProducerMicroservice,

--- a/Source/SDK/DolittleClientService.cs
+++ b/Source/SDK/DolittleClientService.cs
@@ -34,14 +34,14 @@ public class DolittleClientService : IHostedService
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         _logger = _clientConfiguration.LoggerFactory.CreateLogger<DolittleClientService>();
-        Log.ConnectingDolittleClient(_logger);
+        _logger.ConnectingDolittleClient();
         try
         {
             await _dolittleClient.Connect(_clientConfiguration, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            Log.ErrorWhileConnectingDolittleClient(_logger, ex);
+            _logger.ErrorWhileConnectingDolittleClient(ex);
             throw;
         }
     }
@@ -49,7 +49,7 @@ public class DolittleClientService : IHostedService
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        Log.DisconnectingDolittleClient(_logger);
+        _logger.DisconnectingDolittleClient();
         return _dolittleClient.Disconnect(cancellationToken);
     }
 }

--- a/Source/SDK/Handshake/DolittleRuntimeConnector.cs
+++ b/Source/SDK/Handshake/DolittleRuntimeConnector.cs
@@ -84,7 +84,7 @@ public class DolittleRuntimeConnector : IConnectToDolittleRuntime
         {
             try
             {
-                Log.ConnectingToDolittleRuntime(_logger);
+                _logger.ConnectingToDolittleRuntime();
                 var handshakeResult = await _handshakePerformer.Perform(attempts++, DateTimeOffset.Now - startTime, _headVersion, cancellationToken).ConfigureAwait(false);
                 return CreateExecutionContextFromHandshake(handshakeResult);
             }
@@ -94,7 +94,7 @@ public class DolittleRuntimeConnector : IConnectToDolittleRuntime
             }
             catch (Exception ex) when (ex is not DolittleRuntimeFailedHandshake)
             {
-                Log.RetryConnect(_logger, currentWaitTime, ex.Message);
+                _logger.RetryConnect(currentWaitTime, ex.Message);
                 await Task.Delay(currentWaitTime, cancellationToken).ConfigureAwait(false);
                 currentWaitTime = GetTimeToWait(currentWaitTime * 2);
             }

--- a/Source/SDK/Handshake/Internal/HandshakeClient.cs
+++ b/Source/SDK/Handshake/Internal/HandshakeClient.cs
@@ -41,7 +41,7 @@ public class HandshakeClient : IPerformHandshake
         {
             var contractsVersion = Contracts.VersionInfo.CurrentVersion.ToVersion();
             var sdkVersion = VersionInfo.CurrentVersion;
-            Log.PerformHandshake(_logger, headVersion, sdkVersion, contractsVersion);
+            _logger.PerformHandshake(headVersion, sdkVersion, contractsVersion);
             var request = new HandshakeRequest
             {
                 SdkIdentifier = "DotNET",
@@ -56,16 +56,16 @@ public class HandshakeClient : IPerformHandshake
             if (response.Failure != null)
             {
                 var failure = new Failure(response.Failure.Id.ToGuid(), response.Failure.Reason);
-                Log.HandshakeFailedResponse(_logger, failure.Reason, failure.Id);
+                _logger.HandshakeFailedResponse(failure.Reason, failure.Id);
                 throw new DolittleRuntimeFailedHandshake(failure);
             }
 
-            Log.SuccessfullyPerformedHandshake(_logger, headVersion, sdkVersion, contractsVersion, response.RuntimeVersion.ToVersion(), response.ContractsVersion.ToVersion());
+            _logger.SuccessfullyPerformedHandshake(headVersion, sdkVersion, contractsVersion, response.RuntimeVersion.ToVersion(), response.ContractsVersion.ToVersion());
             return new HandshakeResult(response.MicroserviceId.ToGuid(), response.EnvironmentName);
         }
         catch (Exception ex)
         {
-            Log.ErrorPerformingHandshake(_logger, ex);
+            _logger.ErrorPerformingHandshake(ex);
             throw;
         }
     }

--- a/Source/SDK/Handshake/Internal/Log.cs
+++ b/Source/SDK/Handshake/Internal/Log.cs
@@ -8,17 +8,20 @@ using Version = Dolittle.SDK.Microservices.Version;
 
 namespace Dolittle.SDK.Handshake.Internal;
 
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Handshake.Internal"/>.
+/// </summary>
 static partial class Log
 {
     [LoggerMessage(0, LogLevel.Debug, "Performing handshake between Head v{HeadVersion} using Dolittle DotNET SDK v{SDKVersion} using version {ContractsVersion} Contracts and Dolittle Runtime")]
-    internal static partial void PerformHandshake(ILogger logger, Version headVersion, Version sdkVersion, Version contractsVersion);
+    internal static partial void PerformHandshake(this ILogger logger, Version headVersion, Version sdkVersion, Version contractsVersion);
 
     [LoggerMessage(0, LogLevel.Debug, "Error performing handshake with Dolittle Runtime")]
-    internal static partial void ErrorPerformingHandshake(ILogger logger, Exception ex);
+    internal static partial void ErrorPerformingHandshake(this ILogger logger, Exception ex);
 
     [LoggerMessage(0, LogLevel.Warning, "Dolittle Runtime failed performing handshake. ({FailureId}){FailureReason}")]
-    internal static partial void HandshakeFailedResponse(ILogger logger, FailureReason failureReason, FailureId failureId);
+    internal static partial void HandshakeFailedResponse(this ILogger logger, FailureReason failureReason, FailureId failureId);
 
     [LoggerMessage(0, LogLevel.Debug, "Successfully performed handshake between Head v{HeadVersion} using Dolittle DotNET SDK v{SDKVersion} using version {SDKContractsVersion} Contracts and Dolittle Runtime v{RuntimeVersion} using version {RuntimeContractsVersion} Contracts")]
-    internal static partial void SuccessfullyPerformedHandshake(ILogger logger, Version headVersion, Version sdkVersion, Version sdkContractsVersion, Version runtimeVersion, Version runtimeContractsVersion);
+    internal static partial void SuccessfullyPerformedHandshake(this ILogger logger, Version headVersion, Version sdkVersion, Version sdkContractsVersion, Version runtimeVersion, Version runtimeContractsVersion);
 }

--- a/Source/SDK/Handshake/Log.cs
+++ b/Source/SDK/Handshake/Log.cs
@@ -6,11 +6,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Handshake;
 
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Handshake"/>.
+/// </summary>
 static partial class Log
 {
     [LoggerMessage(0, LogLevel.Debug, "Connecting to Dolittle Runtime")]
-    internal static partial void ConnectingToDolittleRuntime(ILogger logger);
+    internal static partial void ConnectingToDolittleRuntime(this ILogger logger);
 
     [LoggerMessage(0, LogLevel.Debug, "Failed connecting to Dolittle Runtime. Retrying in {RetryTime}. {FailureReason}")]
-    internal static partial void RetryConnect(ILogger logger, TimeSpan retryTime, string failureReason);
+    internal static partial void RetryConnect(this ILogger logger, TimeSpan retryTime, string failureReason);
 }

--- a/Source/SDK/Log.cs
+++ b/Source/SDK/Log.cs
@@ -6,14 +6,17 @@ using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK;
 
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK"/>.
+/// </summary>
 static partial class Log
 {
     [LoggerMessage(0, LogLevel.Information, "Connecting Dolittle Client")]
-    internal static partial void ConnectingDolittleClient(ILogger logger);
+    internal static partial void ConnectingDolittleClient(this ILogger logger);
     
     [LoggerMessage(0, LogLevel.Error, "An error occurred while connecting Dolittle Client")]
-    internal static partial void ErrorWhileConnectingDolittleClient(ILogger logger, Exception ex);
+    internal static partial void ErrorWhileConnectingDolittleClient(this ILogger logger, Exception ex);
     
     [LoggerMessage(0, LogLevel.Information, "Disconnecting Dolittle Client")]
-    internal static partial void DisconnectingDolittleClient(ILogger logger);
+    internal static partial void DisconnectingDolittleClient(this ILogger logger);
 }

--- a/Source/Services/Log.cs
+++ b/Source/Services/Log.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Services;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Services"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Trace, "Received ping")]
+    internal static partial void ReceivedPing(this ILogger logger);
+    
+    [LoggerMessage(0, LogLevel.Trace, "Writing pong")]
+    internal static partial void WritingPong(this ILogger logger);
+    
+    [LoggerMessage(0, LogLevel.Trace, "Received connect response")]
+    internal static partial void ReceivedConnectResponse(this ILogger logger);
+
+    [LoggerMessage(0, LogLevel.Warning, "Received a message from Reverse Call Dispatcher while connecting, but it was not a registration response or a ping" )]
+    internal static partial void ReceivedNonPingOrResponseDuringConnect(this ILogger logger);
+
+    [LoggerMessage(0, LogLevel.Warning, "No messages received from the server, connection timed out.")]
+    internal static partial void TimedOutDuringConnect(this ILogger logger);
+
+    [LoggerMessage(0, LogLevel.Debug, "Reverse Call Client was cancelled by client while connecting")]
+    internal static partial void CancelledByClientDuringConnect(this ILogger logger);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Reverse Call Client was cancelled by server while connecting")]
+    internal static partial void CancelledByServerDuringConnect(this ILogger logger);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Received message from Reverse Call Dispatcher while handling, but it was not a request or a ping" )]
+    internal static partial void ReceivedNonPingOrRequestDuringHandling(this ILogger logger);
+
+    [LoggerMessage(0, LogLevel.Debug, "Reverse Call Client was cancelled by client while handling requests")]
+    internal static partial void CancelledByClientDuringHandling(this ILogger logger);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Reverse Call Client was cancelled by server while handling requests")]
+    internal static partial void CancelledByServerDuringHandling(this ILogger logger);
+
+    [LoggerMessage(0, LogLevel.Debug, "Reverse Call Client was cancelled before it could respond with pong")]
+    internal static partial void CancelledBeforePongCouldBeSent(this ILogger logger);
+
+    [LoggerMessage(0, LogLevel.Trace, "Handling request with call '{CallId}'")]
+    internal static partial void HandlingRequest(this ILogger logger, Guid callId);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Error while invoking handler for call '{CallId}'")]
+    internal static partial void ErrorWhileInvokingHandlerFor(this ILogger logger, Guid callId, Exception exception);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Error while writing response for call '{CallId}'")]
+    internal static partial void ErrorWhileWritingResponseFor(this ILogger logger, Guid callId, Exception exception);
+    
+    [LoggerMessage(0, LogLevel.Warning, "An error occurred while handling received request")]
+    internal static partial void ErrorWhileHandlingRequest(this ILogger logger, Exception exception);
+    
+    [LoggerMessage(0, LogLevel.Trace, "Writing response for call '{CallId}'")]
+    internal static partial void WritingResponseFor(this ILogger logger, Guid callId);
+    
+    [LoggerMessage(0, LogLevel.Trace, "Client was cancelled while writing response for call '{CallId}'")]
+    internal static partial void CancelledWhileWritingResponseFor(this ILogger logger, Guid callId);
+}

--- a/Source/Services/ServerStreamingEnumerable.cs
+++ b/Source/Services/ServerStreamingEnumerable.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +33,8 @@ public class ServerStreamingEnumerable<TServerMessage> : IServerStreamingEnumera
     public void Dispose()
     {
         _disposed = true;
-        _call?.Dispose();   
+        _call?.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     /// <inheritdoc />

--- a/Source/Services/Services.csproj
+++ b/Source/Services/Services.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <AssemblyName>Dolittle.SDK.Services</AssemblyName>
+    <RootNamespace>Dolittle.SDK.Services</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Tenancy.Client/Internal/Log.cs
+++ b/Source/Tenancy.Client/Internal/Log.cs
@@ -7,14 +7,17 @@ using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Tenancy.Client.Internal;
 
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Tenancy.Client.Internal"/>.
+/// </summary>
 static partial class Log
 {
     [LoggerMessage(0, LogLevel.Debug, "Getting all Tenants")]
-    internal static partial void GettingAllTenants(ILogger logger);
+    internal static partial void GettingAllTenants(this ILogger logger);
     
     [LoggerMessage(0, LogLevel.Warning, "An error occurred while getting all Tenants because {FailureReason}. Failure Id '{FailureId}'")]
-    internal static partial void FailedGettingAllTenants(ILogger logger, FailureReason failureReason, FailureId failureId);
+    internal static partial void FailedGettingAllTenants(this ILogger logger, FailureReason failureReason, FailureId failureId);
     
     [LoggerMessage(0, LogLevel.Warning, "An error occurred while getting all Tenants")]
-    internal static partial void ErrorGettingTenants(ILogger logger, Exception ex);
+    internal static partial void ErrorGettingTenants(this ILogger logger, Exception ex);
 }

--- a/Source/Tenancy.Client/Internal/TenantsClient.cs
+++ b/Source/Tenancy.Client/Internal/TenantsClient.cs
@@ -38,7 +38,7 @@ public class TenantsClient : ITenants
     /// <inheritdoc />
     public async Task<IEnumerable<Tenant>> GetAll(ExecutionContext executionContext, CancellationToken cancellationToken = default)
     {
-        Log.GettingAllTenants(_logger);
+        _logger.GettingAllTenants();
         try
         {
             var request = new GetAllRequest { CallContext = new CallRequestContext { ExecutionContext = executionContext.ToProtobuf() } };
@@ -48,12 +48,12 @@ public class TenantsClient : ITenants
                 return response.Tenants.Select(CreateTenant);
             }
 
-            Log.FailedGettingAllTenants(_logger, response.Failure.Reason, response.Failure.Id.ToGuid());
+            _logger.FailedGettingAllTenants(response.Failure.Reason, response.Failure.Id.ToGuid());
             throw new FailedToGetAllTenants(response.Failure.Reason);
         }
         catch (Exception ex)
         {
-            Log.ErrorGettingTenants(_logger, ex);
+            _logger.ErrorGettingTenants(ex);
             throw;
         }
     }

--- a/Source/Tenancy.Client/Tenancy.Client.csproj
+++ b/Source/Tenancy.Client/Tenancy.Client.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <AssemblyName>Dolittle.SDK.Tenancy.Client</AssemblyName>
+    <RootNamespace>Dolittle.SDK.Tenancy.Client</RootNamespace>
   </PropertyGroup>
 
     <ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.3.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>7.2.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>6.7.0</ContractsVersion>
+        <ContractsVersion>6.8.0-merry.2</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.3.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>7.2.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>6.8.0-merry.2</ContractsVersion>
+        <ContractsVersion>6.8.0</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>


### PR DESCRIPTION
## Summary

Adds aliases to Projections, in the same way we have for Event Handlers. They default to the name of the read model class, and can be overridden with an attribute argument or a builder method.

### Added

- An optional `alias` argument on the `Projection` attribute.
- A `.WithAlias` method on the Projection builder API.

### Fixed
- A bunch of build warnings, mostly using the code generated logger messages.