### PR TITLE
Call base method explicitly to avoid recursive calls.

### DIFF
--- a/Source/Events.Handling/Builder/Convention/ConventionEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/Convention/ConventionEventHandlerBuilder.cs
@@ -49,6 +49,11 @@ public abstract class ConventionEventHandlerBuilder : ICanTryBuildEventHandler, 
     /// <inheritdoc />
     public bool Equals(ICanTryBuildEventHandler other)
     {
+        if (other == null)
+        {
+            return false;
+        }
+        
         if (ReferenceEquals(this, other))
         {
             return true;

--- a/Source/Events.Handling/Builder/Convention/Instance/ConventionInstanceEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/Convention/Instance/ConventionInstanceEventHandlerBuilder.cs
@@ -32,7 +32,7 @@ public class ConventionInstanceEventHandlerBuilder : ConventionEventHandlerBuild
     
     /// <inheritdoc />
     public bool Equals(ConventionInstanceEventHandlerBuilder other)
-        => other is not null && ((ICanTryBuildEventHandler)this).Equals(other);
+        => base.Equals(other);
 
     /// <inheritdoc />
     public override bool Equals(object other)

--- a/Source/Events.Handling/Builder/Convention/Type/ConventionTypeEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/Convention/Type/ConventionTypeEventHandlerBuilder.cs
@@ -26,7 +26,7 @@ public class ConventionTypeEventHandlerBuilder : ConventionEventHandlerBuilder, 
     
     /// <inheritdoc />
     public bool Equals(ConventionTypeEventHandlerBuilder other)
-        => other is not null && ((ICanTryBuildEventHandler)this).Equals(other);
+        => base.Equals(other);
 
     /// <inheritdoc />
     public override bool Equals(object other)


### PR DESCRIPTION
## Summary

Fixes a bug introduced in the previous release where building Event Handlers would cause a stack overflow because an `Equals(...)` method called itself recursively.

### Fixed

- A bug caused clients that was using Event Handlers to crash with a stack overflow when while setting up the Dolittle Client, because of a recursive call to `Equals(...)` in event handler builders while checking the model.
