### PR TITLE
Upgrade grpc

### DIFF
--- a/Samples/Tutorials/EventHorizon/Environment/consumer-resources.json
+++ b/Samples/Tutorials/EventHorizon/Environment/consumer-resources.json
@@ -5,6 +5,25 @@
                 "mongo"
             ],
             "database": "consumer_event_store"
+        },
+        "projections": {
+            "servers": [
+                "mongo"
+            ],
+            "database": "consumer_projections",
+            "maxConnectionPoolSize": 1000
+        },
+        "embeddings": {
+            "servers": [
+                "mongo"
+            ],
+            "database": "consumer_embeddings",
+            "maxConnectionPoolSize": 1000
+        },
+        "readModels": {
+            "host": "mongodb://localhost:27017",
+            "database": "consumer_readmodels",
+            "useSSL": false
         }
     }
 }

--- a/Samples/Tutorials/EventHorizon/Environment/docker-compose.yml
+++ b/Samples/Tutorials/EventHorizon/Environment/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - ./consumer-platform.json:/app/.dolittle/platform.json
       - ./consumer-resources.json:/app/.dolittle/resources.json
       - ./consumer-microservices.json:/app/.dolittle/microservices.json
-    environment:
-      - Logging__Console__FormatterName=""
     ports:
       - 50054:50052
       - 50055:50053
@@ -26,8 +24,6 @@ services:
       - ./producer-platform.json:/app/.dolittle/platform.json
       - ./producer-resources.json:/app/.dolittle/resources.json
       - ./producer-event-horizon-consents.json:/app/.dolittle/event-horizon-consents.json
-    environment:
-      - Logging__Console__FormatterName=""
     ports:
       - 50052:50052
       - 50053:50053

--- a/Samples/Tutorials/EventHorizon/Environment/docker-compose.yml
+++ b/Samples/Tutorials/EventHorizon/Environment/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - ./consumer-platform.json:/app/.dolittle/platform.json
       - ./consumer-resources.json:/app/.dolittle/resources.json
       - ./consumer-microservices.json:/app/.dolittle/microservices.json
+    environment:
+      - Logging__Console__FormatterName=""
     ports:
       - 50054:50052
       - 50055:50053
@@ -24,6 +26,8 @@ services:
       - ./producer-platform.json:/app/.dolittle/platform.json
       - ./producer-resources.json:/app/.dolittle/resources.json
       - ./producer-event-horizon-consents.json:/app/.dolittle/event-horizon-consents.json
+    environment:
+      - Logging__Console__FormatterName=""
     ports:
       - 50052:50052
       - 50053:50053

--- a/Samples/Tutorials/EventHorizon/Environment/producer-resources.json
+++ b/Samples/Tutorials/EventHorizon/Environment/producer-resources.json
@@ -5,6 +5,25 @@
                 "mongo"
             ],
             "database": "producer_event_store"
+        },
+        "projections": {
+            "servers": [
+                "mongo"
+            ],
+            "database": "producer_projections",
+            "maxConnectionPoolSize": 1000
+        },
+        "embeddings": {
+            "servers": [
+                "mongo"
+            ],
+            "database": "producer_embeddings",
+            "maxConnectionPoolSize": 1000
+        },
+        "readModels": {
+            "host": "mongodb://localhost:27017",
+            "database": "producer_readmodels",
+            "useSSL": false
         }
     }
 }

--- a/Source/Aggregates/Internal/AggregateRootsRegisterAliasMethod.cs
+++ b/Source/Aggregates/Internal/AggregateRootsRegisterAliasMethod.cs
@@ -4,7 +4,6 @@
 using Dolittle.Runtime.Aggregates.Contracts;
 using Dolittle.SDK.Services;
 using Grpc.Core;
-using Grpc.Net.Client;
 
 namespace Dolittle.SDK.Aggregates.Internal;
 

--- a/Source/Aggregates/Internal/AggregateRootsRegisterAliasMethod.cs
+++ b/Source/Aggregates/Internal/AggregateRootsRegisterAliasMethod.cs
@@ -4,6 +4,7 @@
 using Dolittle.Runtime.Aggregates.Contracts;
 using Dolittle.SDK.Services;
 using Grpc.Core;
+using Grpc.Net.Client;
 
 namespace Dolittle.SDK.Aggregates.Internal;
 
@@ -13,7 +14,7 @@ namespace Dolittle.SDK.Aggregates.Internal;
 public class AggregateRootsRegisterAliasMethod : ICanCallAUnaryMethod<AggregateRootAliasRegistrationRequest, AggregateRootAliasRegistrationResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<AggregateRootAliasRegistrationResponse> Call(AggregateRootAliasRegistrationRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<AggregateRootAliasRegistrationResponse> Call(AggregateRootAliasRegistrationRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new Dolittle.Runtime.Aggregates.Contracts.AggregateRoots.AggregateRootsClient(channel);
         return client.RegisterAliasAsync(message, callOptions);

--- a/Source/Embeddings/EmbeddingsDelete.cs
+++ b/Source/Embeddings/EmbeddingsDelete.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Embeddings;
 public class EmbeddingsDelete : ICanCallAUnaryMethod<DeleteRequest, DeleteResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<DeleteResponse> Call(DeleteRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<DeleteResponse> Call(DeleteRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new EmbeddingsClient(channel);
         return client.DeleteAsync(message, callOptions);

--- a/Source/Embeddings/EmbeddingsUpdate.cs
+++ b/Source/Embeddings/EmbeddingsUpdate.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Embeddings;
 public class EmbeddingsUpdate : ICanCallAUnaryMethod<UpdateRequest, UpdateResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<UpdateResponse> Call(UpdateRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<UpdateResponse> Call(UpdateRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new EmbeddingsClient(channel);
         return client.UpdateAsync(message, callOptions);

--- a/Source/Embeddings/Internal/EmbeddingsProtocol.cs
+++ b/Source/Embeddings/Internal/EmbeddingsProtocol.cs
@@ -16,7 +16,7 @@ namespace Dolittle.SDK.Embeddings.Internal;
 public class EmbeddingsProtocol : IAmAReverseCallProtocol<EmbeddingClientToRuntimeMessage, EmbeddingRuntimeToClientMessage, EmbeddingRegistrationRequest, EmbeddingRegistrationResponse, EmbeddingRequest, EmbeddingResponse>
 {
     /// <inheritdoc/>
-    public AsyncDuplexStreamingCall<EmbeddingClientToRuntimeMessage, EmbeddingRuntimeToClientMessage> Call(Channel channel, CallOptions callOptions)
+    public AsyncDuplexStreamingCall<EmbeddingClientToRuntimeMessage, EmbeddingRuntimeToClientMessage> Call(ChannelBase channel, CallOptions callOptions)
         => new EmbeddingsClient(channel).Connect(callOptions);
 
     /// <inheritdoc/>

--- a/Source/Embeddings/Store/EmbeddingsGetAll.cs
+++ b/Source/Embeddings/Store/EmbeddingsGetAll.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Embeddings.Store;
 public class EmbeddingsGetAll : ICanCallAUnaryMethod<GetAllRequest, GetAllResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<GetAllResponse> Call(GetAllRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<GetAllResponse> Call(GetAllRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new EmbeddingStoreClient(channel);
         return client.GetAllAsync(message, callOptions);

--- a/Source/Embeddings/Store/EmbeddingsGetKeys.cs
+++ b/Source/Embeddings/Store/EmbeddingsGetKeys.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Embeddings.Store;
 public class EmbeddingsGetKeys : ICanCallAUnaryMethod<GetKeysRequest, GetKeysResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<GetKeysResponse> Call(GetKeysRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<GetKeysResponse> Call(GetKeysRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new EmbeddingStoreClient(channel);
         return client.GetKeysAsync(message, callOptions);

--- a/Source/Embeddings/Store/EmbeddingsGetOne.cs
+++ b/Source/Embeddings/Store/EmbeddingsGetOne.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Embeddings.Store;
 public class EmbeddingsGetOne : ICanCallAUnaryMethod<GetOneRequest, GetOneResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<GetOneResponse> Call(GetOneRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<GetOneResponse> Call(GetOneRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new EmbeddingStoreClient(channel);
         return client.GetOneAsync(message, callOptions);

--- a/Source/EventHorizon/Internal/SubscriptionsSubscribeMethod.cs
+++ b/Source/EventHorizon/Internal/SubscriptionsSubscribeMethod.cs
@@ -15,7 +15,7 @@ namespace Dolittle.SDK.EventHorizon.Internal;
 public class SubscriptionsSubscribeMethod : ICanCallAUnaryMethod<SubscriptionRequest, SubscriptionResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<SubscriptionResponse> Call(SubscriptionRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<SubscriptionResponse> Call(SubscriptionRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new SubscriptionsClient(channel);
         return client.SubscribeAsync(message, callOptions);

--- a/Source/Events.Filters/Internal/PartitionedEventFilterProtocol.cs
+++ b/Source/Events.Filters/Internal/PartitionedEventFilterProtocol.cs
@@ -15,7 +15,7 @@ namespace Dolittle.SDK.Events.Filters.Internal;
 public class PartitionedEventFilterProtocol : IAmAFilterProtocol<PartitionedFilterClientToRuntimeMessage, PartitionedFilterRegistrationRequest, PartitionedFilterResponse>
 {
     /// <inheritdoc/>
-    public AsyncDuplexStreamingCall<PartitionedFilterClientToRuntimeMessage, FilterRuntimeToClientMessage> Call(Channel channel, CallOptions callOptions)
+    public AsyncDuplexStreamingCall<PartitionedFilterClientToRuntimeMessage, FilterRuntimeToClientMessage> Call(ChannelBase channel, CallOptions callOptions)
         => new FiltersClient(channel).ConnectPartitioned(callOptions);
 
     /// <inheritdoc/>

--- a/Source/Events.Filters/Internal/PublicEventFilterProtocol.cs
+++ b/Source/Events.Filters/Internal/PublicEventFilterProtocol.cs
@@ -15,7 +15,7 @@ namespace Dolittle.SDK.Events.Filters.Internal;
 public class PublicEventFilterProtocol : IAmAFilterProtocol<PublicFilterClientToRuntimeMessage, PublicFilterRegistrationRequest, PartitionedFilterResponse>
 {
     /// <inheritdoc/>
-    public AsyncDuplexStreamingCall<PublicFilterClientToRuntimeMessage, FilterRuntimeToClientMessage> Call(Channel channel, CallOptions callOptions)
+    public AsyncDuplexStreamingCall<PublicFilterClientToRuntimeMessage, FilterRuntimeToClientMessage> Call(ChannelBase channel, CallOptions callOptions)
         => new FiltersClient(channel).ConnectPublic(callOptions);
 
     /// <inheritdoc/>

--- a/Source/Events.Filters/Internal/UnpartitionedEventFilterProtocol.cs
+++ b/Source/Events.Filters/Internal/UnpartitionedEventFilterProtocol.cs
@@ -15,7 +15,7 @@ namespace Dolittle.SDK.Events.Filters.Internal;
 public class UnpartitionedEventFilterProtocol : IAmAFilterProtocol<FilterClientToRuntimeMessage, FilterRegistrationRequest, FilterResponse>
 {
     /// <inheritdoc/>
-    public AsyncDuplexStreamingCall<FilterClientToRuntimeMessage, FilterRuntimeToClientMessage> Call(Channel channel, CallOptions callOptions)
+    public AsyncDuplexStreamingCall<FilterClientToRuntimeMessage, FilterRuntimeToClientMessage> Call(ChannelBase channel, CallOptions callOptions)
         => new FiltersClient(channel).Connect(callOptions);
 
     /// <inheritdoc/>

--- a/Source/Events.Handling/Internal/EventHandlerProtocol.cs
+++ b/Source/Events.Handling/Internal/EventHandlerProtocol.cs
@@ -16,7 +16,7 @@ namespace Dolittle.SDK.Events.Handling.Internal;
 public class EventHandlerProtocol : IAmAReverseCallProtocol<EventHandlerClientToRuntimeMessage, EventHandlerRuntimeToClientMessage, EventHandlerRegistrationRequest, EventHandlerRegistrationResponse, HandleEventRequest, EventHandlerResponse>
 {
     /// <inheritdoc/>
-    public AsyncDuplexStreamingCall<EventHandlerClientToRuntimeMessage, EventHandlerRuntimeToClientMessage> Call(Channel channel, CallOptions callOptions)
+    public AsyncDuplexStreamingCall<EventHandlerClientToRuntimeMessage, EventHandlerRuntimeToClientMessage> Call(ChannelBase channel, CallOptions callOptions)
         => new EventHandlersClient(channel).Connect(callOptions);
 
     /// <inheritdoc/>

--- a/Source/Events.Processing/EventProcessors.cs
+++ b/Source/Events.Processing/EventProcessors.cs
@@ -53,7 +53,7 @@ public class EventProcessors : IEventProcessors
         where TResponse : class
     {
 #if NETCOREAPP3_1
-        if (++_eventProcessoCounter == 100)
+        if (++_eventProcessoCounter >= 100)
         {
             _logger.LogWarning("There are more than 100 event processors registered, this might cause your application to hang when using netcoreapp 3.1. Please reduce the amount of event processors or upgrade your app to use net5 or later version of .NET");
         }

--- a/Source/Events.Processing/EventProcessors.cs
+++ b/Source/Events.Processing/EventProcessors.cs
@@ -20,7 +20,9 @@ public class EventProcessors : IEventProcessors
     readonly ICreateReverseCallClients _reverseCallClientsCreator;
     readonly ICoordinateProcessing _processingCoordinator;
     readonly ILogger _logger;
-
+#if NETCOREAPP3_1
+    ushort _eventProcessoCounter = 0;
+#endif
     /// <summary>
     /// Initializes a new instance of the <see cref="EventProcessors"/> class.
     /// </summary>
@@ -50,6 +52,12 @@ public class EventProcessors : IEventProcessors
         where TRequest : class
         where TResponse : class
     {
+#if NETCOREAPP3_1
+        if (++_eventProcessoCounter == 100)
+        {
+            _logger.LogWarning("There are more than 100 event processors registered, this might cause your application to hang when using netcoreapp 3.1. Please reduce the amount of event processors or upgrade your app to use net5 or later version of .NET");
+        }
+#endif
         var processor = Task.Run(() => RunProcessorForeverUntilCancelled(eventProcessor, protocol, cancellationToken));
         _processingCoordinator.RegisterProcessor(processor);
     }

--- a/Source/Events/Internal/EventTypesRegisterMethod.cs
+++ b/Source/Events/Internal/EventTypesRegisterMethod.cs
@@ -13,7 +13,7 @@ namespace Dolittle.SDK.Events.Internal;
 public class EventTypesRegisterMethod : ICanCallAUnaryMethod<EventTypeRegistrationRequest, EventTypeRegistrationResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<EventTypeRegistrationResponse> Call(EventTypeRegistrationRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<EventTypeRegistrationResponse> Call(EventTypeRegistrationRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new Dolittle.Runtime.Events.Contracts.EventTypes.EventTypesClient(channel);
         return client.RegisterAsync(message, callOptions);

--- a/Source/Events/Store/EventStoreCommitForAggregateMethod.cs
+++ b/Source/Events/Store/EventStoreCommitForAggregateMethod.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Events.Store;
 public class EventStoreCommitForAggregateMethod : ICanCallAUnaryMethod<CommitAggregateEventsRequest, CommitAggregateEventsResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<CommitAggregateEventsResponse> Call(CommitAggregateEventsRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<CommitAggregateEventsResponse> Call(CommitAggregateEventsRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new EventStoreClient(channel);
         return client.CommitForAggregateAsync(message, callOptions);

--- a/Source/Events/Store/EventStoreCommitMethod.cs
+++ b/Source/Events/Store/EventStoreCommitMethod.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Events.Store;
 public class EventStoreCommitMethod : ICanCallAUnaryMethod<CommitEventsRequest, CommitEventsResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<CommitEventsResponse> Call(CommitEventsRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<CommitEventsResponse> Call(CommitEventsRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new EventStoreClient(channel);
         return client.CommitAsync(message, callOptions);

--- a/Source/Events/Store/EventStoreFetchForAggregateMethod.cs
+++ b/Source/Events/Store/EventStoreFetchForAggregateMethod.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Events.Store;
 public class EventStoreFetchForAggregateMethod : ICanCallAUnaryMethod<FetchForAggregateRequest, FetchForAggregateResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<FetchForAggregateResponse> Call(FetchForAggregateRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<FetchForAggregateResponse> Call(FetchForAggregateRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new EventStoreClient(channel);
         return client.FetchForAggregateAsync(message, callOptions);

--- a/Source/Projections/Internal/ProjectionsProtocol.cs
+++ b/Source/Projections/Internal/ProjectionsProtocol.cs
@@ -16,7 +16,7 @@ namespace Dolittle.SDK.Projections.Internal;
 public class ProjectionsProtocol : IAmAReverseCallProtocol<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage, ProjectionRegistrationRequest, ProjectionRegistrationResponse, ProjectionRequest, ProjectionResponse>
 {
     /// <inheritdoc/>
-    public AsyncDuplexStreamingCall<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage> Call(Channel channel, CallOptions callOptions)
+    public AsyncDuplexStreamingCall<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage> Call(ChannelBase channel, CallOptions callOptions)
         => new ProjectionsClient(channel).Connect(callOptions);
 
     /// <inheritdoc/>

--- a/Source/Projections/Store/ProjectionsGetAll.cs
+++ b/Source/Projections/Store/ProjectionsGetAll.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Projections.Store;
 public class ProjectionsGetAll : ICanCallAUnaryMethod<GetAllRequest, GetAllResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<GetAllResponse> Call(GetAllRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<GetAllResponse> Call(GetAllRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new ProjectionsClient(channel);
         return client.GetAllAsync(message, callOptions);

--- a/Source/Projections/Store/ProjectionsGetAllInBatches.cs
+++ b/Source/Projections/Store/ProjectionsGetAllInBatches.cs
@@ -13,7 +13,7 @@ namespace Dolittle.SDK.Projections.Store;
 public class ProjectionsGetAllInBatches : ICanCallAServerStreamingMethod<GetAllRequest, GetAllResponse>
 {
     /// <inheritdoc/>
-    public AsyncServerStreamingCall<GetAllResponse> Call(GetAllRequest message, Channel channel, CallOptions callOptions)
+    public AsyncServerStreamingCall<GetAllResponse> Call(GetAllRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new Runtime.Projections.Contracts.Projections.ProjectionsClient(channel);
         return client.GetAllInBatches(message, callOptions);

--- a/Source/Projections/Store/ProjectionsGetOne.cs
+++ b/Source/Projections/Store/ProjectionsGetOne.cs
@@ -14,7 +14,7 @@ namespace Dolittle.SDK.Projections.Store;
 public class ProjectionsGetOne : ICanCallAUnaryMethod<GetOneRequest, GetOneResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<GetOneResponse> Call(GetOneRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<GetOneResponse> Call(GetOneRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new ProjectionsClient(channel);
         return client.GetOneAsync(message, callOptions);

--- a/Source/Resources/MongoDB/Internal/ResourcesGetMongoDBMethod.cs
+++ b/Source/Resources/MongoDB/Internal/ResourcesGetMongoDBMethod.cs
@@ -13,7 +13,7 @@ namespace Dolittle.SDK.Resources.MongoDB.Internal;
 public class ResourcesGetMongoDBMethod : ICanCallAUnaryMethod<GetRequest, GetMongoDBResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<GetMongoDBResponse> Call(GetRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<GetMongoDBResponse> Call(GetRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new Dolittle.Runtime.Resources.Contracts.Resources.ResourcesClient(channel);
         return client.GetMongoDBAsync(message, callOptions);

--- a/Source/SDK/Handshake/Internal/HandshakeMethod.cs
+++ b/Source/SDK/Handshake/Internal/HandshakeMethod.cs
@@ -13,7 +13,7 @@ namespace Dolittle.SDK.Handshake.Internal;
 public class HandshakeMethod : ICanCallAUnaryMethod<HandshakeRequest, HandshakeResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<HandshakeResponse> Call(HandshakeRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<HandshakeResponse> Call(HandshakeRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new Dolittle.Runtime.Handshake.Contracts.Handshake.HandshakeClient(channel);
         return client.HandshakeAsync(message, callOptions);

--- a/Source/Services/ICanCallADuplexStreamingMethod.cs
+++ b/Source/Services/ICanCallADuplexStreamingMethod.cs
@@ -21,5 +21,5 @@ public interface ICanCallADuplexStreamingMethod<TClientMessage, TServerMessage>
     /// <param name="channel">The <see cref="Channel"/> to use to connect to the server.</param>
     /// <param name="callOptions">The <see cref="CallOptions"/> to use for the call.</param>
     /// <returns>The <see cref="AsyncDuplexStreamingCall{TRequest, TResponse}"/> representing the method call.</returns>
-    AsyncDuplexStreamingCall<TClientMessage, TServerMessage> Call(Channel channel, CallOptions callOptions);
+    AsyncDuplexStreamingCall<TClientMessage, TServerMessage> Call(ChannelBase channel, CallOptions callOptions);
 }

--- a/Source/Services/ICanCallADuplexStreamingMethod.cs
+++ b/Source/Services/ICanCallADuplexStreamingMethod.cs
@@ -18,7 +18,7 @@ public interface ICanCallADuplexStreamingMethod<TClientMessage, TServerMessage>
     /// <summary>
     /// Performs the duplex streaming method call on the server using the provided channel and call options.
     /// </summary>
-    /// <param name="channel">The <see cref="Channel"/> to use to connect to the server.</param>
+    /// <param name="channel">The <see cref="ChannelBase"/> to use to connect to the server.</param>
     /// <param name="callOptions">The <see cref="CallOptions"/> to use for the call.</param>
     /// <returns>The <see cref="AsyncDuplexStreamingCall{TRequest, TResponse}"/> representing the method call.</returns>
     AsyncDuplexStreamingCall<TClientMessage, TServerMessage> Call(ChannelBase channel, CallOptions callOptions);

--- a/Source/Services/ICanCallAServerStreamingMethod.cs
+++ b/Source/Services/ICanCallAServerStreamingMethod.cs
@@ -22,5 +22,5 @@ public interface ICanCallAServerStreamingMethod<in TClientMessage, TServerMessag
     /// <param name="channel">The <see cref="Channel"/> to use to connect to the server.</param>
     /// <param name="callOptions">The <see cref="CallOptions"/> to use for the call.</param>
     /// <returns>The <see cref="AsyncDuplexStreamingCall{TRequest, TResponse}"/> representing the method call.</returns>
-    AsyncServerStreamingCall<TServerMessage> Call(TClientMessage message, Channel channel, CallOptions callOptions);
+    AsyncServerStreamingCall<TServerMessage> Call(TClientMessage message, ChannelBase channel, CallOptions callOptions);
 }

--- a/Source/Services/ICanCallAServerStreamingMethod.cs
+++ b/Source/Services/ICanCallAServerStreamingMethod.cs
@@ -19,7 +19,7 @@ public interface ICanCallAServerStreamingMethod<in TClientMessage, TServerMessag
     /// Performs the server streaming method call on the server using the provided channel and call options.
     /// </summary>
     /// <param name="message">The message to send to the server.</param>
-    /// <param name="channel">The <see cref="Channel"/> to use to connect to the server.</param>
+    /// <param name="channel">The <see cref="ChannelBase"/> to use to connect to the server.</param>
     /// <param name="callOptions">The <see cref="CallOptions"/> to use for the call.</param>
     /// <returns>The <see cref="AsyncDuplexStreamingCall{TRequest, TResponse}"/> representing the method call.</returns>
     AsyncServerStreamingCall<TServerMessage> Call(TClientMessage message, ChannelBase channel, CallOptions callOptions);

--- a/Source/Services/ICanCallAUnaryMethod.cs
+++ b/Source/Services/ICanCallAUnaryMethod.cs
@@ -20,7 +20,7 @@ public interface ICanCallAUnaryMethod<TClientMessage, TServerMessage>
     /// Performs an async unary call on the server using the provided message, channel and call options.
     /// </summary>
     /// <param name="message">The message to send to the server.</param>
-    /// <param name="channel">The <see cref="Channel"/> to use to connect to the server.</param>
+    /// <param name="channel">The <see cref="ChannelBase"/> to use to connect to the server.</param>
     /// <param name="callOptions">The <see cref="CallOptions"/> to use for the call.</param>
     /// <returns>A <see cref="AsyncUnaryCall{TResult}"/> representing the result of the async unary call.</returns>
     AsyncUnaryCall<TServerMessage> Call(TClientMessage message, ChannelBase channel, CallOptions callOptions);

--- a/Source/Services/ICanCallAUnaryMethod.cs
+++ b/Source/Services/ICanCallAUnaryMethod.cs
@@ -3,6 +3,7 @@
 
 using Google.Protobuf;
 using Grpc.Core;
+using Grpc.Net.Client;
 
 namespace Dolittle.SDK.Services;
 
@@ -22,5 +23,5 @@ public interface ICanCallAUnaryMethod<TClientMessage, TServerMessage>
     /// <param name="channel">The <see cref="Channel"/> to use to connect to the server.</param>
     /// <param name="callOptions">The <see cref="CallOptions"/> to use for the call.</param>
     /// <returns>A <see cref="AsyncUnaryCall{TResult}"/> representing the result of the async unary call.</returns>
-    AsyncUnaryCall<TServerMessage> Call(TClientMessage message, Channel channel, CallOptions callOptions);
+    AsyncUnaryCall<TServerMessage> Call(TClientMessage message, ChannelBase channel, CallOptions callOptions);
 }

--- a/Source/Services/ICanCallAUnaryMethod.cs
+++ b/Source/Services/ICanCallAUnaryMethod.cs
@@ -3,7 +3,6 @@
 
 using Google.Protobuf;
 using Grpc.Core;
-using Grpc.Net.Client;
 
 namespace Dolittle.SDK.Services;
 

--- a/Source/Services/ProcessingCoordinator.cs
+++ b/Source/Services/ProcessingCoordinator.cs
@@ -13,13 +13,6 @@ public class ProcessingCoordinator : ICoordinateProcessing
 {
     readonly List<Task> _processors = new();
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ProcessingCoordinator"/> class.
-    /// </summary>
-    public ProcessingCoordinator()
-    {
-    }
-
     /// <inheritdoc/>
     public Task Completion => Task.WhenAll(_processors);
 

--- a/Source/Services/Services.csproj
+++ b/Source/Services/Services.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Grpc" Version="$(GrpcVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="System.Reactive" Version="$(RxVersion)" />
-    <PackageReference Include="Contrib.Grpc.Core.M1" Version="$(GrpcVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Services/Services.csproj
+++ b/Source/Services/Services.csproj
@@ -10,10 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
     <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-    <PackageReference Include="Grpc" Version="$(GrpcVersion)" />
+    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="System.Reactive" Version="$(RxVersion)" />
-    <PackageReference Include="Contrib.Grpc.Core.M1" Version="$(GrpcVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Tenancy.Client/Internal/TenantsGetAllMethod.cs
+++ b/Source/Tenancy.Client/Internal/TenantsGetAllMethod.cs
@@ -13,7 +13,7 @@ namespace Dolittle.SDK.Tenancy.Client.Internal;
 public class TenantsGetAllMethod : ICanCallAUnaryMethod<GetAllRequest, GetAllResponse>
 {
     /// <inheritdoc/>
-    public AsyncUnaryCall<GetAllResponse> Call(GetAllRequest message, Channel channel, CallOptions callOptions)
+    public AsyncUnaryCall<GetAllResponse> Call(GetAllRequest message, ChannelBase channel, CallOptions callOptions)
     {
         var client = new Dolittle.Runtime.Tenancy.Contracts.Tenants.TenantsClient(channel);
         return client.GetAllAsync(message, callOptions);

--- a/versions.props
+++ b/versions.props
@@ -3,14 +3,14 @@
         <AutofacVersion>6.3.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>7.2.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>6.8.0</ContractsVersion>
+        <ContractsVersion>6.8.1</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>
         <MicrosoftDotNetTestVersion>16.4.0</MicrosoftDotNetTestVersion>
         <RxVersion>4.4.1</RxVersion>
         <ProtobufVersion>3.18.1</ProtobufVersion>
-        <GrpcVersion>2.41.0</GrpcVersion>
+        <GrpcVersion>2.43.0</GrpcVersion>
         <MongoDBDriverVersion>2.13.2</MongoDBDriverVersion>
         <NewtonsoftVersion>12.0.3</NewtonsoftVersion>
         <SystemImmutableVersion>1.7.1</SystemImmutableVersion>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.3.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>7.2.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>6.8.1</ContractsVersion>
+        <ContractsVersion>6.8.2</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>


### PR DESCRIPTION
## Summary

Updates grpc packages and uses a single grpc channel for all connections

### Changed

- Updated grpc version to 2.43.0
- Updated contracts version
- Uses one GrpcChannel for all gRPC connections. This is a potential breaking change for netcoreapp 3.1 since it does not allow multiple concurrent http2 connections for one GrpcChannel meaning that if there are 100 or more event processors in a netcoreapp 3.1 application it will start hanging. 

### Removed

- Removed the Contrib.M1 Grpc native executable for arm64. This is no longer needed with the new .NET Grpc packages