### PR TITLE
Update the contracts and grpc versions

### DIFF
--- a/Source/Services/Services.csproj
+++ b/Source/Services/Services.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Grpc" Version="$(GrpcVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="System.Reactive" Version="$(RxVersion)" />
-    <PackageReference Include="Contrib.Grpc.Core.M1" Version="$(GrpcVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -3,14 +3,14 @@
         <AutofacVersion>6.3.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>7.2.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>6.8.0</ContractsVersion>
+        <ContractsVersion>6.8.1</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>
         <MicrosoftDotNetTestVersion>16.4.0</MicrosoftDotNetTestVersion>
         <RxVersion>4.4.1</RxVersion>
         <ProtobufVersion>3.18.1</ProtobufVersion>
-        <GrpcVersion>2.41.0</GrpcVersion>
+        <GrpcVersion>2.43.0</GrpcVersion>
         <MongoDBDriverVersion>2.13.2</MongoDBDriverVersion>
         <NewtonsoftVersion>12.0.3</NewtonsoftVersion>
         <SystemImmutableVersion>1.7.1</SystemImmutableVersion>


### PR DESCRIPTION
## Summary

Update the Grpc Contracts versions

### Changed

- Use version 2.43.0 of Grpc
- Use version 6.8.1 of the Grpc Contracts

### Removed
- Removed the reference to the M1 Grpc native executable package. This is no longer needed with the new dotnet grpc packages