### PR TITLE
Upgrade contracts

### DIFF
--- a/Samples/Tutorials/GettingStarted/DishHandler.cs
+++ b/Samples/Tutorials/GettingStarted/DishHandler.cs
@@ -16,7 +16,7 @@ public class DishHandler
         _logger = logger;
     }
 
-    public void Handle(DishPrepared @event)
+    public void Handle(DishPrepared @event, EventContext context)
     {
         _logger.LogInformation("{Chef} has prepared {Dish}. Yummm!", @event.Chef, @event.Dish);
     }

--- a/Samples/Tutorials/GettingStarted/DishHandler.cs
+++ b/Samples/Tutorials/GettingStarted/DishHandler.cs
@@ -16,7 +16,7 @@ public class DishHandler
         _logger = logger;
     }
 
-    public void Handle(DishPrepared @event, EventContext eventContext)
+    public void Handle(DishPrepared @event)
     {
         _logger.LogInformation("{Chef} has prepared {Dish}. Yummm!", @event.Chef, @event.Dish);
     }

--- a/Samples/Tutorials/GettingStarted/DishHandler.cs
+++ b/Samples/Tutorials/GettingStarted/DishHandler.cs
@@ -16,7 +16,7 @@ public class DishHandler
         _logger = logger;
     }
 
-    public void Handle(DishPrepared @event, EventContext context)
+    public void Handle(DishPrepared @event, EventContext eventContext)
     {
         _logger.LogInformation("{Chef} has prepared {Dish}. Yummm!", @event.Chef, @event.Dish);
     }

--- a/Source/Embeddings/Embeddings.csproj
+++ b/Source/Embeddings/Embeddings.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     </ItemGroup>
 

--- a/Source/Events.Filters/Events.Filters.csproj
+++ b/Source/Events.Filters/Events.Filters.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     </ItemGroup>
 

--- a/Source/Events.Handling/Events.Handling.csproj
+++ b/Source/Events.Handling/Events.Handling.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     </ItemGroup>
 

--- a/Source/Events.Processing/Events.Processing.csproj
+++ b/Source/Events.Processing/Events.Processing.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftVersion)" />
         <PackageReference Include="System.Reactive" Version="$(RxVersion)" />

--- a/Source/Events/Events.csproj
+++ b/Source/Events/Events.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftVersion)" />
         <PackageReference Include="System.Collections.Immutable" Version="$(SystemImmutableVersion)" />

--- a/Source/Projections/Projections.csproj
+++ b/Source/Projections/Projections.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
     </ItemGroup>

--- a/Source/Resources/Resources.csproj
+++ b/Source/Resources/Resources.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
-        <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
     </ItemGroup>
 
   <ItemGroup>

--- a/Source/Tenancy.Client/Tenancy.Client.csproj
+++ b/Source/Tenancy.Client/Tenancy.Client.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
     </ItemGroup>
 
   <ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.3.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>7.2.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>6.8.2</ContractsVersion>
+        <ContractsVersion>7.0.0-meriadoc.0</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.3.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>7.2.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>7.0.0-meriadoc.3</ContractsVersion>
+        <ContractsVersion>7.0.0</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.3.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>7.2.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>7.0.0-meriadoc.0</ContractsVersion>
+        <ContractsVersion>7.0.0-meriadoc.3</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>


### PR DESCRIPTION
## Summary

Use the new breaking contracts version

### Changed

- Uses new version v7 of dolittle contracts compatible with v8 of the Runtime
