### PR TITLE
Fail early when building event handlers with wrong signature

### DIFF
--- a/Source/Events.Handling/Builder/EventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/EventHandlerBuilder.cs
@@ -22,7 +22,6 @@ public class EventHandlerBuilder : IEventHandlerBuilder, ICanTryBuildEventHandle
     bool _hasAlias;
     bool _partitioned = true;
     ScopeId _scopeId = ScopeId.Default;
-    EventHandlerModelId ModelId => new(_eventHandlerId, _scopeId);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EventHandlerBuilder"/> class.
@@ -36,7 +35,12 @@ public class EventHandlerBuilder : IEventHandlerBuilder, ICanTryBuildEventHandle
         _methodsBuilder = new EventHandlerMethodsBuilder(_eventHandlerId);
         Bind();
     }
-
+    
+    /// <summary>
+    /// Gets the <see cref="EventHandlerModelId"/>.
+    /// </summary>
+    public EventHandlerModelId ModelId => new(_eventHandlerId, _scopeId);
+    
     /// <inheritdoc />
     public IEventHandlerMethodsBuilder Partitioned()
     {

--- a/Source/Events.Handling/Builder/EventHandlersBuilder.cs
+++ b/Source/Events.Handling/Builder/EventHandlersBuilder.cs
@@ -92,6 +92,10 @@ public class EventHandlersBuilder : IEventHandlersBuilder
             {
                 eventHandlers.Add(new EventHandlerModelId(eventHandler.Identifier, eventHandler.ScopeId), eventHandler);
             }
+            else
+            {
+                buildResults.AddFailure($"Failed to build Event Handler for '{builder.EventHandlerType}'. It will not be registered");
+            }
         }
         foreach (var (_, builder) in model.GetProcessorBuilderBindings<ConventionInstanceEventHandlerBuilder>())
         {
@@ -99,12 +103,21 @@ public class EventHandlersBuilder : IEventHandlersBuilder
             {
                 eventHandlers.Add(new EventHandlerModelId(eventHandler.Identifier, eventHandler.ScopeId), eventHandler);
             }
+            else
+            {
+                buildResults.AddFailure($"Failed to build Event Handler for instance of '{builder.EventHandlerType}'. It will not be registered");
+            }
         }
         foreach (var (_, builder) in model.GetProcessorBuilderBindings<EventHandlerBuilder>())
         {
             if (builder.TryBuild(eventTypes, buildResults, out var eventHandler))
             {
                 eventHandlers.Add(new EventHandlerModelId(eventHandler.Identifier, eventHandler.ScopeId), eventHandler);
+            }
+            
+            else
+            {
+                buildResults.AddFailure($"Failed to build Event Handler '{builder.ModelId.Id}' in Scope '{builder.ModelId.Scope}'. It will not be registered");
             }
         }
         return new UnregisteredEventHandlers(


### PR DESCRIPTION
## Summary

Fixes an issue where event handlers with wrong signatures were not picked up early so that the developer was met with a confusing error message.


### Changed

- Significantly improves the error messages logged when having event handlers with wrong signatures.
