### PR TITLE
Small fixes in event handler convention builder

### DIFF
--- a/Source/Events.Handling/Builder/Convention/ConventionEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/Convention/ConventionEventHandlerBuilder.cs
@@ -120,15 +120,16 @@ public abstract class ConventionEventHandlerBuilder : ICanTryBuildEventHandler, 
         IDictionary<EventType, IEventHandlerMethod> eventTypesToMethods,
         IClientBuildResults buildResults)
     {
-        var publicMethods = EventHandlerType.GetMethods(BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic);
+        var allDeclaredMethods = EventHandlerType.GetMethods(BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic);
+        
         var hasWrongMethods = !TryAddDecoratedHandlerMethods(
-                publicMethods,
+                allDeclaredMethods,
                 eventHandlerId,
                 createUntypedHandlerMethod,
                 eventTypesToMethods,
                 buildResults)
-            || !TryAddConventionHandlerMethods(
-                publicMethods,
+            | !TryAddConventionHandlerMethods(
+                allDeclaredMethods,
                 eventHandlerId,
                 eventTypes,
                 createTypedHandlerMethod,


### PR DESCRIPTION
## Summary
### Fixed

- A bug where if there were errors while adding decorated event handler methods it would not try to add convention event handler methods