### PR TITLE
Use the whole exception as failure reason

### DIFF
--- a/Source/Events.Processing/Internal/EventProcessor.cs
+++ b/Source/Events.Processing/Internal/EventProcessor.cs
@@ -71,7 +71,7 @@ public abstract class EventProcessor<TIdentifier, TRegisterArguments, TRequest, 
             };
             var failure = new ProcessorFailure
             {
-                Reason = ex.Message,
+                Reason = ex.ToString(),
                 Retry = true,
                 RetryTimeout = retryTimeout
             };


### PR DESCRIPTION
## Summary

### Changed

- Use whole exception as failure reason when processing an event fails.