### PR TITLE
Do not release packages not meant for consumption

### DIFF
--- a/Benchmarks/Directory.Build.props
+++ b/Benchmarks/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+</Project>

--- a/Samples/Directory.Build.props
+++ b/Samples/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+</Project>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
+</Project>

--- a/Specifications/Directory.Build.props
+++ b/Specifications/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

An issue with the previous release resulted in the nuget packages not being published.

### Fixed

- Release pipeline

### Changed

- Use whole exception as failure reason when processing an event fails.