### PR TITLE
Fix resolution of singleton tenant scoped services 

### DIFF
--- a/Samples/DependencyInjection/IGlobalTransientService.cs
+++ b/Samples/DependencyInjection/IGlobalTransientService.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.Logging;
 
 public interface IGlobalTransientService : IDisposable
 {
@@ -6,4 +7,5 @@ public interface IGlobalTransientService : IDisposable
 
 public class GlobalTransientService : Service, IGlobalTransientService
 {
+    public GlobalTransientService(ILogger<TenantScopedTransientService> logger) {}
 }

--- a/Samples/DependencyInjection/ITenantScopedTransientService.cs
+++ b/Samples/DependencyInjection/ITenantScopedTransientService.cs
@@ -1,5 +1,6 @@
 using System;
 using Dolittle.SDK.Tenancy;
+using Microsoft.Extensions.Logging;
 
 public interface ITenantScopedTransientService : IDisposable
 {
@@ -7,7 +8,7 @@ public interface ITenantScopedTransientService : IDisposable
 
 public class TenantScopedTransientService : TenantScopedService, ITenantScopedTransientService
 {
-    public TenantScopedTransientService(TenantId tenant) : base(tenant)
+    public TenantScopedTransientService(TenantId tenant, ILogger<TenantScopedTransientService> logger) : base(tenant)
     {
     }
 }


### PR DESCRIPTION
## Summary

A problem with our tenant scoped service providers caused crashes when resolving tenant scoped singleton services with dependencies not present in the derived tenant scoped service provider directly.

This turned out to be a problem deeply nested into how we try to integrate with Autofac using the capabilities of the standard Microsoft dependency injection framework. It does not allow us to fully take advantage of it. Therefore we're adding two extension packages for our DependencyInversion system, one for setting up the host to use Autofac and one for Lamar. We're also giving the developer the freedom to use their own dependency injection framework of choice by providing a method on `IHostBuilder` called  `UseDolittleTenantContainerCreator` that can be used to setup the system that creates the tenant scoped child containers from the root `IServiceProvider`, though we'd recommend settling for one of the extensions that we provide.

### Changed
- `IAggregateOf<>` registered as `transient` instead of `singleton` services 
- The Dolittle Client will explicitly throw an exception when connecting if there are services configured as Singleton that are not provided an instance due to limitations of the Microsoft dependency injection framework not having support for child containers. For that reason we have provided at the moment two extensions to DependencyInversion, Lamar and Autofac

### Added
- `UseDolittleTenantContainerCreator` method on IHostBuilder for setting up your own dependency injection framework with the tenant scoped provider setup if you don't want to use Autofac or Lamar
- Dolittle.SDK.Extensions.DependencyInversion.Autofac: Sets up Autofac as a service provider on the Host and enables the Dolittle Client to utilise it fully for per-tenant child containers
- Dolittle.SDK.Extensions.DependencyInversion.Autofac: Sets up Autofac as a service provider on the Host and enables the Dolittle Client to utilise it fully for per-tenant child containers
- Sample that shows how to set up DependencyInversion in Dolittle Client using Autofac, Lamar or neither