### PR TITLE
Fix problem with Artifact equality check

### DIFF
--- a/Source/Aggregates/AggregateRootType.cs
+++ b/Source/Aggregates/AggregateRootType.cs
@@ -7,45 +7,43 @@ using Dolittle.SDK.Events;
 namespace Dolittle.SDK.Aggregates;
 
 /// <summary>
-/// Represents the type of an event.
+/// Represents the type of an aggregate root.
 /// </summary>
-public record AggregateRootType : Artifact<AggregateRootId>
+public class AggregateRootType : Artifact<AggregateRootId>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AggregateRootType"/> class.
     /// </summary>
-    /// <param name="id">The <see cref="EventTypeId">unique identifier</see> of the <see cref="AggregateRootType"/>.</param>
+    /// <param name="id">The <see cref="AggregateRootId">unique identifier</see> of the <see cref="AggregateRootType"/>.</param>
     public AggregateRootType(AggregateRootId id)
-        : this(id, alias: null)
+        : this(id, Generation.First, null)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AggregateRootType"/> class.
     /// </summary>
-    /// <param name="id">The <see cref="EventTypeId">unique identifier</see> of the <see cref="AggregateRootType"/>.</param>
+    /// <param name="id">The <see cref="AggregateRootId">unique identifier</see> of the <see cref="AggregateRootType"/>.</param>
     /// <param name="alias"><see cref="AggregateRootAlias">Alias</see> of the <see cref="AggregateRootType"/>.</param>
     public AggregateRootType(AggregateRootId id, AggregateRootAlias alias)
-        : base(id)
+        : this(id, Generation.First, alias)
     {
-        ThrowIfAggregateRootTypeIdIsNull(id);
-        Alias = alias;
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AggregateRootType"/> class.
     /// </summary>
-    /// <param name="id">The <see cref="EventTypeId">unique identifier</see> of the <see cref="AggregateRootType"/>.</param>
+    /// <param name="id">The <see cref="AggregateRootId">unique identifier</see> of the <see cref="AggregateRootType"/>.</param>
     /// <param name="generation"><see cref="Generation">Generation</see> of the <see cref="AggregateRootType"/>.</param>
     public AggregateRootType(AggregateRootId id, Generation generation)
         : this(id, generation, null)
     {
     }
-
+    
     /// <summary>
     /// Initializes a new instance of the <see cref="AggregateRootType"/> class.
     /// </summary>
-    /// <param name="id">The <see cref="EventTypeId">unique identifier</see> of the <see cref="AggregateRootType"/>.</param>
+    /// <param name="id">The <see cref="AggregateRootId">unique identifier</see> of the <see cref="AggregateRootType"/>.</param>
     /// <param name="generation"><see cref="Generation">Generation</see> of the <see cref="AggregateRootType"/>.</param>
     /// <param name="alias"><see cref="AggregateRootAlias">Alias</see> of the <see cref="AggregateRootType"/>.</param>
     public AggregateRootType(AggregateRootId id, Generation generation, AggregateRootAlias alias)
@@ -57,14 +55,14 @@ public record AggregateRootType : Artifact<AggregateRootId>
     }
 
     /// <summary>
-    /// Gets the alias for the Event Type.
+    /// Gets the alias for the Aggregate Root.
     /// </summary>
-    public AggregateRootAlias Alias { get; }
+    public AggregateRootAlias? Alias { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the Event Type has an alias or not.
+    /// Gets a value indicating whether the Aggregate Root has an alias or not.
     /// </summary>
-    public bool HasAlias => Alias?.Value != default;
+    public bool HasAlias => !string.IsNullOrEmpty(Alias?.Value);
 
     static void ThrowIfAggregateRootTypeIdIsNull(AggregateRootId id)
     {

--- a/Source/Artifacts/Artifact.cs
+++ b/Source/Artifacts/Artifact.cs
@@ -8,8 +8,6 @@ using Dolittle.SDK.Concepts;
 
 namespace Dolittle.SDK.Artifacts;
 
-
-
 /// <summary>
 /// Represents the base representation of an artifact.
 /// </summary>
@@ -89,7 +87,7 @@ public abstract class Artifact<TId> : IIdentifier<TId>, IEquatable<Artifact<TId>
         {
             return true;
         }
-        return obj.GetType() == this.GetType() && Equals((Artifact<TId>) obj);
+        return obj.GetType() == GetType() && Equals((Artifact<TId>) obj);
     }
 
     /// <inheritdoc />

--- a/Source/Artifacts/Artifact.cs
+++ b/Source/Artifacts/Artifact.cs
@@ -2,18 +2,19 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Dolittle.SDK.Common.Model;
 using Dolittle.SDK.Concepts;
 
 namespace Dolittle.SDK.Artifacts;
 
+
+
 /// <summary>
 /// Represents the base representation of an artifact.
 /// </summary>
 /// <typeparam name="TId">The <see cref="Type" /> of the <see cref="ArtifactId" />.</typeparam>
-/// <param name="Id"><typeparamref name="TId">Id</typeparamref> of the <see cref="Artifact{TId}"/>.</param>
-/// <param name="Generation"><see cref="Generation">Generation</see> of the <see cref="Artifact{TId}"/>.</param>
-public abstract record Artifact<TId>(TId Id, Generation Generation) : IIdentifier<TId>
+public abstract class Artifact<TId> : IIdentifier<TId>, IEquatable<Artifact<TId>>
     where TId : ArtifactId
 {
     /// <summary>
@@ -24,6 +25,27 @@ public abstract record Artifact<TId>(TId Id, Generation Generation) : IIdentifie
         : this(id, Generation.First)
     {
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Artifact{TId}"/> class.
+    /// </summary>
+    /// <param name="id"><typeparamref name="TId">Id</typeparamref> of the <see cref="Artifact{TId}"/>.</param>
+    /// <param name="generation"><see cref="Generation">Generation</see> of the <see cref="Artifact{TId}"/>.</param>
+    protected Artifact(TId id, Generation generation)
+    {
+        Id = id;
+        Generation = generation;
+    }
+    
+    /// <summary>
+    /// Gets the <typeparamref name="TId">Id</typeparamref> of the <see cref="Artifact{TId}"/>.
+    /// </summary>
+    public TId Id { get; }
+
+    /// <summary>
+    /// Gets the <see cref="Generation">Generation</see> of the <see cref="Artifact{TId}"/>.
+    /// </summary>
+    public Generation Generation { get; }
 
     /// <inheritdoc />
     Guid IIdentifier.Id => Id.Value;
@@ -41,4 +63,36 @@ public abstract record Artifact<TId>(TId Id, Generation Generation) : IIdentifie
 
     /// <inheritdoc />
     public bool CanCoexistWith(IIdentifier identifier) => identifier is IIdentifier<TId> typedIdentifier && CanCoexistWith(typedIdentifier);
+
+    /// <inheritdoc />
+    public bool Equals(Artifact<TId> other)
+    {
+        if (ReferenceEquals(null, other))
+        {
+            return false;
+        }
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+        return EqualityComparer<TId>.Default.Equals(Id, other.Id) && Equals(Generation, other.Generation);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj))
+        {
+            return false;
+        }
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+        return obj.GetType() == this.GetType() && Equals((Artifact<TId>) obj);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(Id, Generation);
 }

--- a/Source/Artifacts/Artifacts.cs
+++ b/Source/Artifacts/Artifacts.cs
@@ -13,7 +13,7 @@ namespace Dolittle.SDK.Artifacts;
 /// <typeparam name="TArtifact">The <see cref="Type" /> of the <see cref="Artifact{TId}" />.</typeparam>
 /// <typeparam name="TId">The <see cref="Type" /> of the <see cref="ArtifactId" />.</typeparam>
 public abstract class Artifacts<TArtifact, TId> : UniqueBindings<TArtifact, Type>, IArtifacts<TArtifact, TId>
-    where TArtifact : Artifact<TId>, IEquatable<TArtifact>
+    where TArtifact : Artifact<TId>
     where TId : ArtifactId
 {
     /// <summary>

--- a/Source/Artifacts/IArtifacts.cs
+++ b/Source/Artifacts/IArtifacts.cs
@@ -13,7 +13,7 @@ namespace Dolittle.SDK.Artifacts;
 /// <typeparam name="TArtifact">The <see cref="Type" /> of the <see cref="Artifact{TId}" />.</typeparam>
 /// <typeparam name="TId">The <see cref="Type" /> of the <see cref="ArtifactId" />.</typeparam>
 public interface IArtifacts<TArtifact, TId> : IUniqueBindings<TArtifact, Type>
-    where TArtifact : Artifact<TId>, IEquatable<TArtifact>
+    where TArtifact : Artifact<TId>
     where TId : ArtifactId
 {
     /// <summary>

--- a/Source/Events/EventType.cs
+++ b/Source/Events/EventType.cs
@@ -38,7 +38,7 @@ public class EventType : Artifact<EventTypeId>
         : this(id, generation, null)
     {
     }
-    
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EventType"/> class.
     /// </summary>

--- a/Source/Events/EventType.cs
+++ b/Source/Events/EventType.cs
@@ -8,16 +8,15 @@ namespace Dolittle.SDK.Events;
 /// <summary>
 /// Represents the type of an event.
 /// </summary>
-public record EventType : Artifact<EventTypeId>
+public class EventType : Artifact<EventTypeId>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="EventType"/> class.
     /// </summary>
     /// <param name="id">The <see cref="EventTypeId">unique identifier</see> of the <see cref="EventType"/>.</param>
     public EventType(EventTypeId id)
-        : base(id)
+        : this(id, Generation.First, null)
     {
-        ThrowIfEventTypeIdIsNull(id);
     }
 
     /// <summary>
@@ -26,11 +25,8 @@ public record EventType : Artifact<EventTypeId>
     /// <param name="id">The <see cref="EventTypeId">unique identifier</see> of the <see cref="EventType"/>.</param>
     /// <param name="alias"><see cref="EventTypeAlias">Alias</see> of the <see cref="EventType"/>.</param>
     public EventType(EventTypeId id, EventTypeAlias alias)
-        : base(id)
+        : this(id, Generation.First, alias)
     {
-        ThrowIfEventTypeIdIsNull(id);
-        Alias = alias;
-        HasAlias = true;
     }
 
     /// <summary>
@@ -39,12 +35,10 @@ public record EventType : Artifact<EventTypeId>
     /// <param name="id">The <see cref="EventTypeId">unique identifier</see> of the <see cref="EventType"/>.</param>
     /// <param name="generation"><see cref="Generation">Generation</see> of the <see cref="EventType"/>.</param>
     public EventType(EventTypeId id, Generation generation)
-        : base(id, generation)
+        : this(id, generation, null)
     {
-        ThrowIfEventTypeIdIsNull(id);
-        ThrowIfGenerationIsNull(generation);
     }
-
+    
     /// <summary>
     /// Initializes a new instance of the <see cref="EventType"/> class.
     /// </summary>
@@ -57,18 +51,17 @@ public record EventType : Artifact<EventTypeId>
         ThrowIfEventTypeIdIsNull(id);
         ThrowIfGenerationIsNull(generation);
         Alias = alias;
-        HasAlias = true;
     }
 
     /// <summary>
     /// Gets the alias for the Event Type.
     /// </summary>
-    public EventTypeAlias Alias { get; }
+    public EventTypeAlias? Alias { get; }
 
     /// <summary>
     /// Gets a value indicating whether the Event Type has an alias or not.
     /// </summary>
-    public bool HasAlias { get; }
+    public bool HasAlias => !string.IsNullOrEmpty(Alias?.Value);
 
     static void ThrowIfEventTypeIdIsNull(EventTypeId id)
     {

--- a/Source/Events/Store/Converters/EventContentSerializer.cs
+++ b/Source/Events/Store/Converters/EventContentSerializer.cs
@@ -74,19 +74,17 @@ public class EventContentSerializer : ISerializeEventContent
             var type = _eventTypes.GetTypeFor(eventType);
             content = JsonConvert.DeserializeObject(json, type, serializerSettings);
 
-            if (exceptionCatcher.Failed)
-                deserializationError = new CouldNotDeserializeEventContent(eventType, sequenceNumber, json, exceptionCatcher.Error, type);
-            else
-                deserializationError = null;
+            deserializationError = exceptionCatcher.Failed
+                ? new CouldNotDeserializeEventContent(eventType, sequenceNumber, json, exceptionCatcher.Error, type)
+                : null;
         }
         else
         {
             content = JsonConvert.DeserializeObject(json, serializerSettings);
 
-            if (exceptionCatcher.Failed)
-                deserializationError = new CouldNotDeserializeEventContent(eventType, sequenceNumber, json, exceptionCatcher.Error);
-            else
-                deserializationError = null;
+            deserializationError = exceptionCatcher.Failed
+                ? new CouldNotDeserializeEventContent(eventType, sequenceNumber, json, exceptionCatcher.Error)
+                : null;
         }
 
         return !exceptionCatcher.Failed;

--- a/Specifications/Artifacts/for_Artifacts/given/artifact_type.cs
+++ b/Specifications/Artifacts/for_Artifacts/given/artifact_type.cs
@@ -3,7 +3,7 @@
 
 namespace Dolittle.SDK.Artifacts.for_Artifacts.given;
 
-public record artifact_type : Artifact<ArtifactId>
+public class artifact_type : Artifact<ArtifactId>
 {
     public artifact_type(ArtifactId id)
         : base(id)

--- a/Specifications/Events/Events.csproj
+++ b/Specifications/Events/Events.csproj
@@ -4,6 +4,7 @@
 
     <PropertyGroup>
         <AssemblyName>Dolittle.SDK.Events.Specs</AssemblyName>
+        <RootNamespace>Dolittle.SDK.Events</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Specifications/Events/for_EventType/when_checking_equality/and_one_does_not_have_alias.cs
+++ b/Specifications/Events/for_EventType/when_checking_equality/and_one_does_not_have_alias.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.SDK.Events.for_EventType.when_checking_equality;
+
+public class and_one_does_not_have_alias
+{
+    static EventType first;
+    static EventType second;
+
+    Establish context = () =>
+    {
+        first = new EventType("0f025f6c-41be-4192-895d-c1c771832bae", 2, "alias");
+        second = new EventType("0f025f6c-41be-4192-895d-c1c771832bae", 2, null);
+    };
+    
+    static bool result;
+
+    Because of = () => result = first.Equals(second);
+
+    It should_return_true = () => result.ShouldBeTrue();
+}

--- a/Specifications/Events/for_EventType/when_checking_equality/and_they_are_equal.cs
+++ b/Specifications/Events/for_EventType/when_checking_equality/and_they_are_equal.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.SDK.Events.for_EventType.when_checking_equality;
+
+public class and_they_are_equal
+{
+    static EventType first;
+    static EventType second;
+
+    Establish context = () =>
+    {
+        first = new EventType("0f025f6c-41be-4192-895d-c1c771832bae", 2, "alias");
+        second = new EventType("0f025f6c-41be-4192-895d-c1c771832bae", 2, "alias");
+    };
+    
+    static bool result;
+
+    Because of = () => result = first.Equals(second);
+
+    It should_return_true = () => result.ShouldBeTrue();
+}

--- a/Specifications/Events/for_EventType/when_checking_equality/and_they_are_the_same.cs
+++ b/Specifications/Events/for_EventType/when_checking_equality/and_they_are_the_same.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.SDK.Events.for_EventType.when_checking_equality;
+
+public class and_they_are_the_same_object
+{
+    static EventType first;
+    static EventType second;
+
+    Establish context = () =>
+    {
+        first = new EventType("0f025f6c-41be-4192-895d-c1c771832bae", 2, "alias");
+        second = first;
+    };
+    
+    static bool result;
+
+    Because of = () => result = first.Equals(second);
+
+    It should_return_true = () => result.ShouldBeTrue();
+}

--- a/Specifications/Protobuf/for_ArtifactExtensions/given/artifact_type_with_base_artifact_id.cs
+++ b/Specifications/Protobuf/for_ArtifactExtensions/given/artifact_type_with_base_artifact_id.cs
@@ -5,7 +5,7 @@ using Dolittle.SDK.Artifacts;
 
 namespace Dolittle.SDK.Protobuf.for_ArtifactExtensions.given;
 
-public record artifact_type_with_base_artifact_id : Artifact<ArtifactId>
+public class artifact_type_with_base_artifact_id : Artifact<ArtifactId>
 {
     public artifact_type_with_base_artifact_id(ArtifactId id, Generation generation)
         : base(id, generation)

--- a/Specifications/Protobuf/for_ArtifactExtensions/given/artifact_type_with_custom_artifact_id.cs
+++ b/Specifications/Protobuf/for_ArtifactExtensions/given/artifact_type_with_custom_artifact_id.cs
@@ -5,7 +5,7 @@ using Dolittle.SDK.Artifacts;
 
 namespace Dolittle.SDK.Protobuf.for_ArtifactExtensions.given;
 
-public record artifact_type_with_custom_artifact_id : Artifact<custom_artifact_id>
+public class artifact_type_with_custom_artifact_id : Artifact<custom_artifact_id>
 {
     public artifact_type_with_custom_artifact_id(custom_artifact_id id, Generation generation)
         : base(id, generation)

--- a/Specifications/Protobuf/for_ArtifactExtensions/given/artifact_type_with_custom_artifact_id_without_parameterless_constructor.cs
+++ b/Specifications/Protobuf/for_ArtifactExtensions/given/artifact_type_with_custom_artifact_id_without_parameterless_constructor.cs
@@ -5,7 +5,7 @@ using Dolittle.SDK.Artifacts;
 
 namespace Dolittle.SDK.Protobuf.for_ArtifactExtensions.given;
 
-public record artifact_type_with_custom_artifact_id_without_parameterless_constructor : Artifact<artifact_id_without_parameterless_constructor>
+public class artifact_type_with_custom_artifact_id_without_parameterless_constructor : Artifact<artifact_id_without_parameterless_constructor>
 {
     public artifact_type_with_custom_artifact_id_without_parameterless_constructor(artifact_id_without_parameterless_constructor id, Generation generation)
         : base(id, generation)

--- a/Specifications/Protobuf/for_ArtifactExtensions/given/artifact_type_without_id_and_generation_constructor.cs
+++ b/Specifications/Protobuf/for_ArtifactExtensions/given/artifact_type_without_id_and_generation_constructor.cs
@@ -5,7 +5,7 @@ using Dolittle.SDK.Artifacts;
 
 namespace Dolittle.SDK.Protobuf.for_ArtifactExtensions.given;
 
-public record artifact_type_without_id_and_generation_constructor : Artifact<ArtifactId>
+public class artifact_type_without_id_and_generation_constructor : Artifact<ArtifactId>
 {
     public artifact_type_without_id_and_generation_constructor(ArtifactId id)
         : base(id, Generation.First)

--- a/default.props
+++ b/default.props
@@ -10,6 +10,7 @@
         <PackageReleaseNotes>https://github.com/dolittle/DotNET.SDK/blob/master/CHANGELOG.md</PackageReleaseNotes>
         <DocumentationFile>bin/$(Configuration)/$(TargetFramework)/$(AssemblyName).xml</DocumentationFile>
         <NoWarn>$(NoWarn);SYSLIB1002;SYSLIB1006;SYSLIB1007</NoWarn>
+        <Nullable>enable</Nullable>
 
         <Description>Dolittle is a decentralized, distributed, event-driven microservice platform built to harness the power of events.</Description>
         <PackageTags>Dolittle;Events;Event Sourcing;Domain Driven Design;Event Driven Architecture;Line of Business;ES;DDD;EDA;LOB</PackageTags>


### PR DESCRIPTION
## Summary

Fixes a problem with Artifacts caused event types with specified Alias to cause exception when being handled by an event handler

### Fixed

- EventType with explicit Alias should now work.
