### PR TITLE
Set max size of receive and send messages to 32 mb

### DIFF
--- a/Source/SDK/DolittleClient.cs
+++ b/Source/SDK/DolittleClient.cs
@@ -233,6 +233,8 @@ public class DolittleClient : IDisposable, IDolittleClient
                 new GrpcChannelOptions
                 {
                     Credentials = ChannelCredentials.Insecure,
+                    MaxReceiveMessageSize = 32 * 1024 * 1024,
+                    MaxSendMessageSize = 32 * 1024 * 1024,
 #if NET5_0_OR_GREATER
                     HttpHandler = new SocketsHttpHandler
                     {


### PR DESCRIPTION
## Summary

We have experienced applications that were crashing due to grpc messages growing too big due to the volume of events for an aggregate root. As a quick workaround for this we can increase the maximum size of the grpc messages. In the long term a better solution will be to implement streaming and batch mechanisms.

### Changed

- The max size of grpc messages to 32 mb
