### PR TITLE
Aggregate events streaming

### DIFF
--- a/Source/Aggregates/ActivityExtensions.cs
+++ b/Source/Aggregates/ActivityExtensions.cs
@@ -12,8 +12,7 @@ namespace Dolittle.SDK.Aggregates;
 public static class ActivityExtensions
 {
     const string AggregateRootId = "aggregate.id";
-
-
+    
     /// <summary>
     /// Set parent execution context if spanId is present
     /// </summary>

--- a/Source/Aggregates/AggregateRoot.cs
+++ b/Source/Aggregates/AggregateRoot.cs
@@ -128,32 +128,6 @@ public class AggregateRoot
     public void ApplyPublic(object @event, EventType eventType)
         => Apply(@event, eventType, true);
 
-    /// <summary>
-    /// Re-apply events from the Event Store.
-    /// </summary>
-    /// <remarks>
-    /// This method is not supposed to be used by application code.
-    /// This is for internal rehydration of aggregate roots.
-    /// </remarks>
-    /// <param name="events">Sequence that contains the events to re-apply.</param>
-    [Obsolete("This should eventually be removed from the AggregateRoot interface and replaced by an internal method")]
-    public virtual void ReApply(CommittedAggregateEvents events)
-    {
-        ThrowIfEventWasAppliedToOtherEventSource(events);
-        ThrowIfEventWasAppliedByOtherAggregateRoot(events);
-        if (IsStateless || !events.HasEvents)
-        {
-            Version = events.AggregateRootVersion;
-            return;
-        }
-
-        foreach (var @event in events)
-        {
-            Version = @event.AggregateRootVersion + 1;
-            InvokeOnMethod(@event.Content);
-        }
-    }
-    
     internal virtual void Rehydrate(CommittedAggregateEvents events)
     {
         ThrowIfEventWasAppliedToOtherEventSource(events);

--- a/Source/Aggregates/AggregateRoot.cs
+++ b/Source/Aggregates/AggregateRoot.cs
@@ -128,7 +128,11 @@ public class AggregateRoot
     public void ApplyPublic(object @event, EventType eventType)
         => Apply(@event, eventType, true);
 
-    internal virtual void Rehydrate(CommittedAggregateEvents events)
+    /// <summary>
+    /// Rehydrates the aggregate root with the <see cref="CommittedAggregateEvents"/> for this aggregate.
+    /// </summary>
+    /// <param name="events">The <see cref="CommittedAggregateEvents"/> to rehydrate with.</param>
+    public void Rehydrate(CommittedAggregateEvents events)
     {
         ThrowIfEventWasAppliedToOtherEventSource(events);
         ThrowIfEventWasAppliedByOtherAggregateRoot(events);

--- a/Source/Aggregates/AggregateRoot.cs
+++ b/Source/Aggregates/AggregateRoot.cs
@@ -14,18 +14,18 @@ namespace Dolittle.SDK.Aggregates;
 /// <summary>
 /// Represents the aggregate root.
 /// </summary>
-public class AggregateRoot
+public abstract class AggregateRoot
 {
     readonly List<AppliedEvent> _appliedEvents = new();
-    AggregateRootId? _aggregateRootId;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AggregateRoot"/> class.
     /// </summary>
     /// <param name="eventSourceId">The <see cref="Events.EventSourceId" />.</param>
-    public AggregateRoot(EventSourceId eventSourceId)
+    protected AggregateRoot(EventSourceId eventSourceId)
     {
         EventSourceId = eventSourceId;
+        AggregateRootId = this.GetAggregateRootId();
         Version = AggregateRootVersion.Initial;
         IsStateless = this.IsStateless();
     }
@@ -38,7 +38,7 @@ public class AggregateRoot
     /// <summary>
     /// Gets the <see cref="Events.AggregateRootId"/>.
     /// </summary>
-    public AggregateRootId AggregateRootId => _aggregateRootId ??= this.GetAggregateRootId();
+    public AggregateRootId AggregateRootId { get; }
 
     /// <summary>
     /// Gets the <see cref="Events.EventSourceId" /> that the <see cref="AggregateRoot" /> applies events to.
@@ -170,7 +170,7 @@ public class AggregateRoot
     }
 
 
-    void Apply(object @event, EventType eventType, bool isPublic)
+    void Apply(object @event, EventType? eventType, bool isPublic)
     {
         if (@event == null)
         {

--- a/Source/Aggregates/AggregateRootExtensions.cs
+++ b/Source/Aggregates/AggregateRootExtensions.cs
@@ -54,7 +54,10 @@ public static class AggregateRootExtensions
     {
         var aggregateRootType = aggregateRoot.GetType();
         var aggregateRootAttribute = aggregateRootType.GetCustomAttribute<AggregateRootAttribute>();
-        if (aggregateRootAttribute == null) throw new MissingAggregateRootAttribute(aggregateRootType);
+        if (aggregateRootAttribute == null)
+        {
+            throw new MissingAggregateRootAttribute(aggregateRootType);
+        }
         return aggregateRootAttribute.Type.Id;
     }
 

--- a/Source/Aggregates/AggregateRootExtensions.cs
+++ b/Source/Aggregates/AggregateRootExtensions.cs
@@ -37,6 +37,15 @@ public static class AggregateRootExtensions
         => GetHandleMethodsFor(aggregateRoot.GetType()).Count == 0;
 
     /// <summary>
+    /// Gets all the <see cref="IEnumerable{T}"/> of <see cref="EventType"/> that the 
+    /// </summary>
+    /// <param name="aggregateRoot"></param>
+    /// <param name="eventTypes"></param>
+    /// <returns></returns>
+    public static IEnumerable<EventType> GetEventTypes(this AggregateRoot aggregateRoot, IEventTypes eventTypes)
+        => GetHandleMethodsFor(aggregateRoot.GetType()).Keys.Select(eventTypes.GetFor);
+
+    /// <summary>
     /// Gets the <see cref="AggregateRootId" /> of an <see cref="AggregateRoot" />.
     /// </summary>
     /// <param name="aggregateRoot">The <see cref="AggregateRoot" />.</param>

--- a/Source/Aggregates/AppliedEvent.cs
+++ b/Source/Aggregates/AppliedEvent.cs
@@ -16,7 +16,7 @@ public class AppliedEvent
     /// <param name="event">The event content.</param>
     /// <param name="eventType">The <see cref="EventType" />.</param>
     /// <param name="isPublic">Whether the event is public or not.</param>
-    public AppliedEvent(object @event, EventType eventType, bool isPublic)
+    public AppliedEvent(object @event, EventType? eventType, bool isPublic)
     {
         Event = @event;
         EventType = eventType;
@@ -31,7 +31,7 @@ public class AppliedEvent
     /// <summary>
     /// Gets the event's <see cref="EventType" />.
     /// </summary>
-    public EventType EventType { get; }
+    public EventType? EventType { get; }
 
     /// <summary>
     /// Gets a value indicating whether this event is public or not.

--- a/Source/Aggregates/Log.cs
+++ b/Source/Aggregates/Log.cs
@@ -15,8 +15,8 @@ static partial class Log
     [LoggerMessage(0, LogLevel.Debug,"Performing operation on {AggregateRoot} with aggregate root id {AggregateRootId} applying events to event source {EventSource}")]
     internal static partial void PerformingOn(this ILogger logger, Type aggregateRoot, AggregateRootId aggregateRootId, EventSourceId eventSource);
     
-    [LoggerMessage(0, LogLevel.Debug, "Re-applying events for {AggregateRoot} with aggregate root id {AggregateRootId} with event source id {EventSource}")]
-    internal static partial void ReApplyingEventsFor(this ILogger logger, Type aggregateRoot, AggregateRootId aggregateRootId, EventSourceId eventSource);
+    [LoggerMessage(0, LogLevel.Debug, "Rehydrating {AggregateRoot} with aggregate root id {AggregateRootId} with event source id {EventSource}")]
+    internal static partial void RehydratingAggregateRoot(this ILogger logger, Type aggregateRoot, AggregateRootId aggregateRootId, EventSourceId eventSource);
 
     [LoggerMessage(0, LogLevel.Trace, "Re-applying {NumberOfEvents} events")]
     internal static partial void ReApplying(this ILogger logger, int numberOfEvents);

--- a/Source/Aggregates/NoCommittedAggregateEventsBatches.cs
+++ b/Source/Aggregates/NoCommittedAggregateEventsBatches.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Events;
+
+namespace Dolittle.SDK.Aggregates;
+
+/// <summary>
+/// Exception that gets thrown when the fetched aggregate root event stream has no batches.
+/// </summary>
+public class NoCommittedAggregateEventsBatches : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NoCommittedAggregateEventsBatches"/> class.
+    /// </summary>
+    /// <param name="aggregateRootId">The aggregate root id.</param>
+    /// <param name="eventSourceId">The event source id.</param>
+    public NoCommittedAggregateEventsBatches(AggregateRootId aggregateRootId, EventSourceId eventSourceId)
+        : base($"No batches of committed aggregate events were received when fetching for aggregate root '{aggregateRootId}' with event source '{eventSourceId}'")
+    {
+    }
+}

--- a/Source/Events/Store/AggregaterootVersionIsOutOfOrder.cs
+++ b/Source/Events/Store/AggregaterootVersionIsOutOfOrder.cs
@@ -14,9 +14,9 @@ public class AggregateRootVersionIsOutOfOrder : ArgumentException
     /// Initializes a new instance of the <see cref="AggregateRootVersionIsOutOfOrder"/> class.
     /// </summary>
     /// <param name="eventVersion">The <see cref="AggregateRootVersion"/> the Event was applied by.</param>
-    /// <param name="expectedVersion">Expected <see cref="AggregateRootVersion"/>.</param>
-    public AggregateRootVersionIsOutOfOrder(AggregateRootVersion eventVersion, AggregateRootVersion expectedVersion)
-        : base($"Aggregate Root version is out of order. Version '{eventVersion}' from event does not match '{expectedVersion}'")
+    /// <param name="previousVersion">Previous <see cref="AggregateRootVersion"/>.</param>
+    public AggregateRootVersionIsOutOfOrder(AggregateRootVersion eventVersion, AggregateRootVersion previousVersion)
+        : base($"Aggregate Root version is out of order. Version '{eventVersion}' from event is not greater than previous version '{previousVersion}'")
     {
     }
 }

--- a/Source/Events/Store/Builders/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.cs
+++ b/Source/Events/Store/Builders/CommitForAggregateWithEventSourceAndExpectedVersionBuilder.cs
@@ -52,7 +52,10 @@ public class CommitForAggregateWithEventSourceAndExpectedVersionBuilder
         Action<UncommittedAggregateEventsBuilder> callback,
         CancellationToken cancellationToken = default)
     {
-        if (_builder != default) throw new EventBuilderMethodAlreadyCalled("Commit");
+        if (_builder != default)
+        {
+            throw new EventBuilderMethodAlreadyCalled("Commit");
+        }
         _builder = new UncommittedAggregateEventsBuilder(_aggregateRootId, _eventSourceId, _expectedVersion);
         callback(_builder);
         var uncommittedAggregateEvents = _builder.Build(_eventTypes);

--- a/Source/Events/Store/Converters/AggregateEventToSDKConverter.cs
+++ b/Source/Events/Store/Converters/AggregateEventToSDKConverter.cs
@@ -63,8 +63,6 @@ public class AggregateEventToSDKConverter : IConvertAggregateEventsToSDK
         var committedEvents = source.ToArray();
         for (ulong i = 0; i < (ulong)committedEvents.Length; i++)
         {
-            // We have to manually calculate and set the AggregateRootVersion for the events as the
-            // CommittedAggregateEvents.AggregateRootVersion is set to the latest version.
             var sourceEvent = committedEvents[i];
 
             if (!TryConvert(sourceEvent, eventSourceId, aggregateRootId, out var @event, out error))

--- a/Source/Events/Store/Converters/AggregateEventToSDKConverter.cs
+++ b/Source/Events/Store/Converters/AggregateEventToSDKConverter.cs
@@ -41,12 +41,12 @@ public class AggregateEventToSDKConverter : IConvertAggregateEventsToSDK
             return false;
         }
 
-        if (!TryConvert(source.Events, source.EventSourceId, aggregateRootId, source.AggregateRootVersion, out var committedAggregateEventList, out error))
+        if (!TryConvert(source.Events, source.EventSourceId, aggregateRootId, out var committedAggregateEventList, out error))
         {
             return false;
         }
 
-        events = new CommittedAggregateEvents(source.EventSourceId, aggregateRootId, committedAggregateEventList);
+        events = new CommittedAggregateEvents(source.EventSourceId, aggregateRootId, source.CurrentAggregateRootVersion, committedAggregateEventList);
         error = null;
         return true;
     }
@@ -55,7 +55,6 @@ public class AggregateEventToSDKConverter : IConvertAggregateEventsToSDK
         IEnumerable<Runtime.Events.Contracts.CommittedAggregateEvents.Types.CommittedAggregateEvent> source,
         EventSourceId eventSourceId,
         AggregateRootId aggregateRootId,
-        AggregateRootVersion aggregateRootVersion,
         out List<CommittedAggregateEvent> events,
         out Exception error)
     {
@@ -66,10 +65,9 @@ public class AggregateEventToSDKConverter : IConvertAggregateEventsToSDK
         {
             // We have to manually calculate and set the AggregateRootVersion for the events as the
             // CommittedAggregateEvents.AggregateRootVersion is set to the latest version.
-            var version = aggregateRootVersion + 1u - (ulong)committedEvents.Length + i;
             var sourceEvent = committedEvents[i];
 
-            if (!TryConvert(sourceEvent, eventSourceId, aggregateRootId, version, out var @event, out error))
+            if (!TryConvert(sourceEvent, eventSourceId, aggregateRootId, out var @event, out error))
             {
                 return false;
             }
@@ -86,7 +84,6 @@ public class AggregateEventToSDKConverter : IConvertAggregateEventsToSDK
         Runtime.Events.Contracts.CommittedAggregateEvents.Types.CommittedAggregateEvent source,
         EventSourceId eventSourceId,
         AggregateRootId aggregateRootId,
-        AggregateRootVersion aggregateRootVersion,
         out CommittedAggregateEvent result,
         out Exception error)
     {
@@ -134,7 +131,7 @@ public class AggregateEventToSDKConverter : IConvertAggregateEventsToSDK
             source.Occurred.ToDateTimeOffset(),
             eventSourceId,
             aggregateRootId,
-            aggregateRootVersion,
+            source.AggregateRootVersion,
             executionContext,
             eventType,
             content,

--- a/Source/Events/Store/EventStore.cs
+++ b/Source/Events/Store/EventStore.cs
@@ -76,4 +76,12 @@ public class EventStore : IEventStore
         IEnumerable<EventType> eventTypes,
         CancellationToken cancellationToken = default)
         => _eventsForAggregate.FetchForAggregate(aggregateRootId, eventSourceId, eventTypes, cancellationToken);
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<CommittedAggregateEvents> FetchStreamForAggregate(AggregateRootId aggregateRootId, EventSourceId eventSourceId, CancellationToken cancellationToken = default)
+        => _eventsForAggregate.FetchStreamForAggregate(aggregateRootId, eventSourceId, cancellationToken);
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<CommittedAggregateEvents> FetchStreamForAggregate(AggregateRootId aggregateRootId, EventSourceId eventSourceId, IEnumerable<EventType> eventTypes, CancellationToken cancellationToken = default)
+        => _eventsForAggregate.FetchStreamForAggregate(aggregateRootId, eventSourceId, eventTypes, cancellationToken);
 }

--- a/Source/Events/Store/EventStore.cs
+++ b/Source/Events/Store/EventStore.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.SDK.Events.Store.Builders;
@@ -66,5 +68,13 @@ public class EventStore : IEventStore
         AggregateRootId aggregateRootId,
         EventSourceId eventSourceId,
         CancellationToken cancellationToken = default)
-        => _eventsForAggregate.FetchForAggregate(aggregateRootId, eventSourceId, cancellationToken);
+        => FetchForAggregate(aggregateRootId, eventSourceId, Enumerable.Empty<EventType>(), cancellationToken);
+    
+    /// <inheritdoc/>
+    public Task<CommittedAggregateEvents> FetchForAggregate(
+        AggregateRootId aggregateRootId,
+        EventSourceId eventSourceId,
+        IEnumerable<EventType> eventTypes,
+        CancellationToken cancellationToken = default)
+        => _eventsForAggregate.FetchForAggregate(aggregateRootId, eventSourceId, eventTypes, cancellationToken);
 }

--- a/Source/Events/Store/EventStore.cs
+++ b/Source/Events/Store/EventStore.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.SDK.Events.Store.Builders;
@@ -68,7 +67,7 @@ public class EventStore : IEventStore
         AggregateRootId aggregateRootId,
         EventSourceId eventSourceId,
         CancellationToken cancellationToken = default)
-        => FetchForAggregate(aggregateRootId, eventSourceId, Enumerable.Empty<EventType>(), cancellationToken);
+        => _eventsForAggregate.FetchForAggregate(aggregateRootId, eventSourceId, cancellationToken);
     
     /// <inheritdoc/>
     public Task<CommittedAggregateEvents> FetchForAggregate(

--- a/Source/Events/Store/EventStoreFetchForAggregateInBatchesMethod.cs
+++ b/Source/Events/Store/EventStoreFetchForAggregateInBatchesMethod.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Events.Contracts;
+using Dolittle.SDK.Services;
+using Grpc.Core;
+
+namespace Dolittle.SDK.Events.Store;
+
+/// <summary>
+/// Represents a wrapper for gRPC EventStore.FetchForAggregateInBatches.
+/// </summary>
+public class EventStoreFetchForAggregateInBatchesMethod : ICanCallAServerStreamingMethod<FetchForAggregateInBatchesRequest, FetchForAggregateResponse>
+{
+    /// <inheritdoc/>
+    public AsyncServerStreamingCall<FetchForAggregateResponse> Call(FetchForAggregateInBatchesRequest message, ChannelBase channel, CallOptions callOptions)
+    {
+        var client = new Runtime.Events.Contracts.EventStore.EventStoreClient(channel);
+        return client.FetchForAggregateInBatches(message, callOptions);
+    }
+}

--- a/Source/Events/Store/IFetchEventsForAggregate.cs
+++ b/Source/Events/Store/IFetchEventsForAggregate.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,5 +23,22 @@ public interface IFetchEventsForAggregate
     Task<CommittedAggregateEvents> FetchForAggregate(
         AggregateRootId aggregateRootId,
         EventSourceId eventSourceId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches the <see cref="CommittedAggregateEvents" /> for an aggregate root.
+    /// </summary>
+    /// <param name="aggregateRootId">The <see cref="AggregateRootId" /> of the aggregate root.</param>
+    /// <param name="eventSourceId">The <see cref="EventSourceId"/>.</param>
+    /// <param name="eventTypes">
+    /// The <see cref="IEnumerable{T}"/> of <see cref="EventType"/> of the events to fetch.
+    /// If none event types are given then it will get all the committed aggregate events for the aggregate root.
+    /// </param>
+    /// <param name="cancellationToken">Token that can be used to cancel this operation.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="CommittedAggregateEvents" />.</returns>
+    Task<CommittedAggregateEvents> FetchForAggregate(
+        AggregateRootId aggregateRootId,
+        EventSourceId eventSourceId,
+        IEnumerable<EventType> eventTypes,
         CancellationToken cancellationToken = default);
 }

--- a/Source/Events/Store/IFetchEventsForAggregate.cs
+++ b/Source/Events/Store/IFetchEventsForAggregate.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,6 +33,32 @@ public interface IFetchEventsForAggregate
     /// <param name="cancellationToken">Token that can be used to cancel this operation.</param>
     /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="CommittedAggregateEvents" />.</returns>
     Task<CommittedAggregateEvents> FetchForAggregate(
+        AggregateRootId aggregateRootId,
+        EventSourceId eventSourceId,
+        IEnumerable<EventType> eventTypes,
+        CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Fetches all the <see cref="CommittedAggregateEvents" /> for an aggregate root.
+    /// </summary>
+    /// <param name="aggregateRootId">The <see cref="AggregateRootId" /> of the aggregate root.</param>
+    /// <param name="eventSourceId">The <see cref="EventSourceId" />.</param>
+    /// <param name="cancellationToken">Token that can be used to cancel this operation.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="CommittedAggregateEvents" />.</returns>
+    IAsyncEnumerable<CommittedAggregateEvents> FetchStreamForAggregate(
+        AggregateRootId aggregateRootId,
+        EventSourceId eventSourceId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches a subset of the <see cref="CommittedAggregateEvents" /> for an aggregate root based on the <see cref="EventType"/>.
+    /// </summary>
+    /// <param name="aggregateRootId">The <see cref="AggregateRootId" /> of the aggregate root.</param>
+    /// <param name="eventSourceId">The <see cref="EventSourceId"/>.</param>
+    /// <param name="eventTypes">The <see cref="IEnumerable{T}"/> of <see cref="EventType"/> of the events to fetch.</param>
+    /// <param name="cancellationToken">Token that can be used to cancel this operation.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="CommittedAggregateEvents" />.</returns>
+    IAsyncEnumerable<CommittedAggregateEvents> FetchStreamForAggregate(
         AggregateRootId aggregateRootId,
         EventSourceId eventSourceId,
         IEnumerable<EventType> eventTypes,

--- a/Source/Events/Store/IFetchEventsForAggregate.cs
+++ b/Source/Events/Store/IFetchEventsForAggregate.cs
@@ -20,6 +20,7 @@ public interface IFetchEventsForAggregate
     /// <param name="eventSourceId">The <see cref="EventSourceId" />.</param>
     /// <param name="cancellationToken">Token that can be used to cancel this operation.</param>
     /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="CommittedAggregateEvents" />.</returns>
+    [Obsolete($"This method is superseded by FetchForAggregate that takes in a collection of event types used to specify which aggregate events to get.")]
     Task<CommittedAggregateEvents> FetchForAggregate(
         AggregateRootId aggregateRootId,
         EventSourceId eventSourceId,

--- a/Source/Events/Store/IFetchEventsForAggregate.cs
+++ b/Source/Events/Store/IFetchEventsForAggregate.cs
@@ -14,27 +14,23 @@ namespace Dolittle.SDK.Events.Store;
 public interface IFetchEventsForAggregate
 {
     /// <summary>
-    /// Fetches the <see cref="CommittedAggregateEvents" /> for an aggregate root.
+    /// Fetches all the <see cref="CommittedAggregateEvents" /> for an aggregate root.
     /// </summary>
     /// <param name="aggregateRootId">The <see cref="AggregateRootId" /> of the aggregate root.</param>
     /// <param name="eventSourceId">The <see cref="EventSourceId" />.</param>
     /// <param name="cancellationToken">Token that can be used to cancel this operation.</param>
     /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="CommittedAggregateEvents" />.</returns>
-    [Obsolete($"This method is superseded by FetchForAggregate that takes in a collection of event types used to specify which aggregate events to get.")]
     Task<CommittedAggregateEvents> FetchForAggregate(
         AggregateRootId aggregateRootId,
         EventSourceId eventSourceId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Fetches the <see cref="CommittedAggregateEvents" /> for an aggregate root.
+    /// Fetches a subset of the <see cref="CommittedAggregateEvents" /> for an aggregate root based on the <see cref="EventType"/>.
     /// </summary>
     /// <param name="aggregateRootId">The <see cref="AggregateRootId" /> of the aggregate root.</param>
     /// <param name="eventSourceId">The <see cref="EventSourceId"/>.</param>
-    /// <param name="eventTypes">
-    /// The <see cref="IEnumerable{T}"/> of <see cref="EventType"/> of the events to fetch.
-    /// If none event types are given then it will get all the committed aggregate events for the aggregate root.
-    /// </param>
+    /// <param name="eventTypes">The <see cref="IEnumerable{T}"/> of <see cref="EventType"/> of the events to fetch.</param>
     /// <param name="cancellationToken">Token that can be used to cancel this operation.</param>
     /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="CommittedAggregateEvents" />.</returns>
     Task<CommittedAggregateEvents> FetchForAggregate(

--- a/Source/Events/Store/Internal/Log.cs
+++ b/Source/Events/Store/Internal/Log.cs
@@ -30,8 +30,8 @@ static partial class Log
     [LoggerMessage(0, LogLevel.Error, "The Runtime acknowledges that the events have been committed, but the returned CommittedEvents could not be converted.")]
     internal static partial void CommittedEventsCouldNotBeConverted(this ILogger logger, Exception ex);
     
-    [LoggerMessage(0, LogLevel.Debug, "Fetching all events for aggregate root {AggregateRoot} and event source {EventSource} that is of one of the following event types: [{EventTypes}]")]
-    internal static partial void FetchingEventsForAggregate(this ILogger logger, AggregateRootId aggregateRoot, EventSourceId eventSource);
+    [LoggerMessage(0, LogLevel.Debug, "Fetching all events for aggregate root {AggregateRoot} and event source {EventSource}")]
+    internal static partial void FetchingAllEventsForAggregate(this ILogger logger, AggregateRootId aggregateRoot, EventSourceId eventSource);
     
     [LoggerMessage(0, LogLevel.Debug, "Fetching events for aggregate root {AggregateRoot} and event source {EventSource} that is of one of the following event types: [{EventTypes}]")]
     internal static partial void FetchingEventsForAggregate(this ILogger logger, AggregateRootId aggregateRoot, EventSourceId eventSource, IEnumerable<EventType> eventTypes);

--- a/Source/Events/Store/Internal/Log.cs
+++ b/Source/Events/Store/Internal/Log.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Events.Store.Internal;
@@ -29,8 +30,11 @@ static partial class Log
     [LoggerMessage(0, LogLevel.Error, "The Runtime acknowledges that the events have been committed, but the returned CommittedEvents could not be converted.")]
     internal static partial void CommittedEventsCouldNotBeConverted(this ILogger logger, Exception ex);
     
-    [LoggerMessage(0, LogLevel.Debug, "Fetching events for aggregate root {AggregateRoot} and event source {EventSource}")]
+    [LoggerMessage(0, LogLevel.Debug, "Fetching all events for aggregate root {AggregateRoot} and event source {EventSource} that is of one of the following event types: [{EventTypes}]")]
     internal static partial void FetchingEventsForAggregate(this ILogger logger, AggregateRootId aggregateRoot, EventSourceId eventSource);
+    
+    [LoggerMessage(0, LogLevel.Debug, "Fetching events for aggregate root {AggregateRoot} and event source {EventSource} that is of one of the following event types: [{EventTypes}]")]
+    internal static partial void FetchingEventsForAggregate(this ILogger logger, AggregateRootId aggregateRoot, EventSourceId eventSource, IEnumerable<EventType> eventTypes);
     
     [LoggerMessage(0, LogLevel.Error, "Could not convert CommittedAggregateEvents to SDK.")]
     internal static partial void FetchedEventsForAggregateCouldNotBeConverted(this ILogger logger, Exception ex);

--- a/Specifications/Aggregates/for_AggregateRoot/given/committed_events_and_two_aggregate_roots.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/given/committed_events_and_two_aggregate_roots.cs
@@ -65,7 +65,7 @@ public abstract class committed_events_and_two_aggregate_roots : two_aggregate_r
                 1 => second_event,
                 2 => third_event
             };
-            yield return new CommittedAggregateEvents(eventSource, aggregateRootId, 3, new []
+            var events = new[]
             {
                 build_committed_event(
                     eventSource,
@@ -75,8 +75,21 @@ public abstract class committed_events_and_two_aggregate_roots : two_aggregate_r
                     @event,
                     event_types.GetFor(@event.GetType()),
                     false,
-                    executionContext)
-            });
+                    executionContext),
+            };
+            if (i == 2)
+            {
+                events = events.Append(build_committed_event(
+                    eventSource,
+                    aggregateRootId,
+                    i + 1,
+                    i + 1,
+                    @event,
+                    event_types.GetFor(@event.GetType()),
+                    false,
+                    executionContext)).ToArray();
+            }
+            yield return new CommittedAggregateEvents(eventSource, aggregateRootId, 4, events);
         }
     }
 

--- a/Specifications/Aggregates/for_AggregateRoot/given/committed_events_and_two_aggregate_roots.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/given/committed_events_and_two_aggregate_roots.cs
@@ -61,7 +61,7 @@ public abstract class committed_events_and_two_aggregate_roots : two_aggregate_r
                 false,
                 executionContext),
         };
-        return new CommittedAggregateEvents(eventSource, aggregateRootId, events);
+        return new CommittedAggregateEvents(eventSource, aggregateRootId, 3, events);
     }
 
     static CommittedAggregateEvent build_committed_event(

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/batched_events_to_a_stateful_aggregate_root.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/batched_events_to_a_stateful_aggregate_root.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using Dolittle.SDK.Events;
+using Machine.Specifications;
+
+namespace Dolittle.SDK.Aggregates.for_AggregateRoot.when_reapplying;
+
+public class batched_events_to_a_stateful_aggregate_root : given.committed_events_and_two_aggregate_roots
+{
+    Because of = () => statefull_aggregate_root.Rehydrate(build_committed_events_batches(event_source_id, statefull_aggregate_root.GetAggregateRootId(), execution_context), CancellationToken.None).GetAwaiter().GetResult();
+
+    It should_be_at_version_three = () => statefull_aggregate_root.Version.ShouldEqual<AggregateRootVersion>(4);
+    It should_handle_simple_event_two_times = () => statefull_aggregate_root.AnEventOnCalled.ShouldEqual(2);
+    It should_handle_another_event_one_time = () => statefull_aggregate_root.AnotherEventOnCalled.ShouldEqual(2);
+    It should_have_no_uncommitted_events = () => statefull_aggregate_root.AppliedEvents.ShouldBeEmpty();
+}

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/batched_events_to_a_stateless_aggregate_root.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/batched_events_to_a_stateless_aggregate_root.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using Dolittle.SDK.Events;
+using Machine.Specifications;
+
+namespace Dolittle.SDK.Aggregates.for_AggregateRoot.when_reapplying;
+
+public class batched_events_to_a_stateless_aggregate_root : given.committed_events_and_two_aggregate_roots
+{
+
+    Because of = () => stateless_aggregate_root.Rehydrate(build_committed_events_batches(event_source_id, stateless_aggregate_root.GetAggregateRootId(), execution_context), CancellationToken.None).GetAwaiter().GetResult();
+
+    It should_be_at_version_three = () => stateless_aggregate_root.Version.ShouldEqual<AggregateRootVersion>(4);
+    It should_have_no_uncommitted_events = () => stateless_aggregate_root.AppliedEvents.ShouldBeEmpty();
+}

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_stateful_aggregate_root.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_stateful_aggregate_root.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Events.Store;
 using Machine.Specifications;
@@ -9,11 +10,7 @@ namespace Dolittle.SDK.Aggregates.for_AggregateRoot.when_reapplying;
 
 public class events_to_a_stateful_aggregate_root : given.committed_events_and_two_aggregate_roots
 {
-    static CommittedAggregateEvents events;
-
-    Establish context = () => events = build_committed_events(event_source_id, statefull_aggregate_root.GetAggregateRootId(), execution_context);
-
-    Because of = () => statefull_aggregate_root.Rehydrate(events);
+    Because of = () => statefull_aggregate_root.Rehydrate(build_committed_events(event_source_id, statefull_aggregate_root.GetAggregateRootId(), execution_context), CancellationToken.None).GetAwaiter().GetResult();
 
     It should_be_at_version_three = () => statefull_aggregate_root.Version.ShouldEqual<AggregateRootVersion>(3);
     It should_handle_simple_event_two_times = () => statefull_aggregate_root.AnEventOnCalled.ShouldEqual(2);

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_stateful_aggregate_root.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_stateful_aggregate_root.cs
@@ -13,7 +13,7 @@ public class events_to_a_stateful_aggregate_root : given.committed_events_and_tw
 
     Establish context = () => events = build_committed_events(event_source_id, statefull_aggregate_root.GetAggregateRootId(), execution_context);
 
-    Because of = () => statefull_aggregate_root.ReApply(events);
+    Because of = () => statefull_aggregate_root.Rehydrate(events);
 
     It should_be_at_version_three = () => statefull_aggregate_root.Version.ShouldEqual<AggregateRootVersion>(3);
     It should_handle_simple_event_two_times = () => statefull_aggregate_root.AnEventOnCalled.ShouldEqual(2);

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_stateless_aggregate_root.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_stateless_aggregate_root.cs
@@ -13,7 +13,7 @@ public class events_to_a_stateless_aggregate_root : given.committed_events_and_t
 
     Establish context = () => events = build_committed_events(event_source_id, stateless_aggregate_root.GetAggregateRootId(), execution_context);
 
-    Because of = () => stateless_aggregate_root.ReApply(events);
+    Because of = () => stateless_aggregate_root.Rehydrate(events);
 
     It should_be_at_version_three = () => stateless_aggregate_root.Version.ShouldEqual<AggregateRootVersion>(3);
     It should_have_no_uncommitted_events = () => stateless_aggregate_root.AppliedEvents.ShouldBeEmpty();

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_stateless_aggregate_root.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_stateless_aggregate_root.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Events.Store;
 using Machine.Specifications;
@@ -9,11 +10,8 @@ namespace Dolittle.SDK.Aggregates.for_AggregateRoot.when_reapplying;
 
 public class events_to_a_stateless_aggregate_root : given.committed_events_and_two_aggregate_roots
 {
-    static CommittedAggregateEvents events;
 
-    Establish context = () => events = build_committed_events(event_source_id, stateless_aggregate_root.GetAggregateRootId(), execution_context);
-
-    Because of = () => stateless_aggregate_root.Rehydrate(events);
+    Because of = () => stateless_aggregate_root.Rehydrate(build_committed_events(event_source_id, stateless_aggregate_root.GetAggregateRootId(), execution_context), CancellationToken.None).GetAwaiter().GetResult();
 
     It should_be_at_version_three = () => stateless_aggregate_root.Version.ShouldEqual<AggregateRootVersion>(3);
     It should_have_no_uncommitted_events = () => stateless_aggregate_root.AppliedEvents.ShouldBeEmpty();

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_wrong_aggregate_type.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_wrong_aggregate_type.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Events.Store;
 using Machine.Specifications;
@@ -10,12 +11,9 @@ namespace Dolittle.SDK.Aggregates.for_AggregateRoot.when_reapplying;
 
 public class events_to_a_wrong_aggregate_type : given.committed_events_and_two_aggregate_roots
 {
-    static CommittedAggregateEvents events;
     static Exception exception;
 
-    Establish context = () => events = build_committed_events(event_source_id, stateless_aggregate_root.GetAggregateRootId(), execution_context);
-
-    Because of = () => exception = Catch.Exception(() => statefull_aggregate_root.Rehydrate(events));
+    Because of = () => exception = Catch.Exception(() => statefull_aggregate_root.Rehydrate(build_committed_events(event_source_id, stateless_aggregate_root.GetAggregateRootId(), execution_context), CancellationToken.None).GetAwaiter().GetResult());
 
     It should_throw_an_exception = () => exception.ShouldBeOfExactType<EventWasAppliedByOtherAggregateRoot>();
     It should_be_at_version_three = () => statefull_aggregate_root.Version.ShouldEqual(AggregateRootVersion.Initial);

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_wrong_aggregate_type.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_wrong_aggregate_type.cs
@@ -15,7 +15,7 @@ public class events_to_a_wrong_aggregate_type : given.committed_events_and_two_a
 
     Establish context = () => events = build_committed_events(event_source_id, stateless_aggregate_root.GetAggregateRootId(), execution_context);
 
-    Because of = () => exception = Catch.Exception(() => statefull_aggregate_root.ReApply(events));
+    Because of = () => exception = Catch.Exception(() => statefull_aggregate_root.Rehydrate(events));
 
     It should_throw_an_exception = () => exception.ShouldBeOfExactType<EventWasAppliedByOtherAggregateRoot>();
     It should_be_at_version_three = () => statefull_aggregate_root.Version.ShouldEqual(AggregateRootVersion.Initial);

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_wrong_event_source.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_wrong_event_source.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Events.Store;
 using Machine.Specifications;
@@ -10,12 +11,9 @@ namespace Dolittle.SDK.Aggregates.for_AggregateRoot.when_reapplying;
 
 public class events_to_a_wrong_event_source : given.committed_events_and_two_aggregate_roots
 {
-    static CommittedAggregateEvents events;
     static Exception exception;
 
-    Establish context = () => events = build_committed_events("aa81d146-0c45-4121-bce0-fcc547257ccd", statefull_aggregate_root.GetAggregateRootId(), execution_context);
-
-    Because of = () => exception = Catch.Exception(() => statefull_aggregate_root.Rehydrate(events));
+    Because of = () => exception = Catch.Exception(() => statefull_aggregate_root.Rehydrate(build_committed_events("aa81d146-0c45-4121-bce0-fcc547257ccd", statefull_aggregate_root.GetAggregateRootId(), execution_context), CancellationToken.None).GetAwaiter().GetResult());
 
     It should_throw_an_exception = () => exception.ShouldBeOfExactType<EventWasAppliedToOtherEventSource>();
     It should_be_at_version_three = () => statefull_aggregate_root.Version.ShouldEqual(AggregateRootVersion.Initial);

--- a/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_wrong_event_source.cs
+++ b/Specifications/Aggregates/for_AggregateRoot/when_reapplying/events_to_a_wrong_event_source.cs
@@ -15,7 +15,7 @@ public class events_to_a_wrong_event_source : given.committed_events_and_two_agg
 
     Establish context = () => events = build_committed_events("aa81d146-0c45-4121-bce0-fcc547257ccd", statefull_aggregate_root.GetAggregateRootId(), execution_context);
 
-    Because of = () => exception = Catch.Exception(() => statefull_aggregate_root.ReApply(events));
+    Because of = () => exception = Catch.Exception(() => statefull_aggregate_root.Rehydrate(events));
 
     It should_throw_an_exception = () => exception.ShouldBeOfExactType<EventWasAppliedToOtherEventSource>();
     It should_be_at_version_three = () => statefull_aggregate_root.Version.ShouldEqual(AggregateRootVersion.Initial);

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/given/committed_aggregate_events_and_a_converter.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/given/committed_aggregate_events_and_a_converter.cs
@@ -31,7 +31,7 @@ public class committed_aggregate_events_and_a_converter : a_converter_and_a_prot
         event_source = "Rena Pearson";
         aggregate_root_id = "717915c1-bb88-4bec-b1c1-61451c5a6608";
 
-        aggregate_root_version = 186206759u;
+        aggregate_root_version = 0;
         occured = new DateTimeOffset(2018, 5, 12, 22, 17, 19, TimeSpan.Zero);
         event_log_sequence_number = 1581420095;
 

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/given/committed_aggregate_events_and_a_converter.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/given/committed_aggregate_events_and_a_converter.cs
@@ -49,6 +49,7 @@ public class committed_aggregate_events_and_a_converter : a_converter_and_a_prot
             EventSourceId = event_source.Value,
             AggregateRootId = aggregate_root_id.ToProtobuf(),
             AggregateRootVersion = aggregate_root_version,
+            CurrentAggregateRootVersion = aggregate_root_version,
             Events = { committed_aggregate_event }
         };
     };

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_aggregate_root_id_is_null.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_aggregate_root_id_is_null.cs
@@ -22,7 +22,8 @@ public class and_aggregate_root_id_is_null : given.committed_aggregate_events_an
             EventSourceId = event_source.Value,
             AggregateRootId = null,
             AggregateRootVersion = aggregate_root_version,
-            Events = { committed_aggregate_event }
+            Events = { committed_aggregate_event },
+            CurrentAggregateRootVersion = aggregate_root_version
         };
 
         object_from_serializer = new object();

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_content_is_empty.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_content_is_empty.cs
@@ -34,6 +34,7 @@ public class and_content_is_empty : given.committed_aggregate_events_and_a_conve
             EventSourceId = event_source.Value,
             AggregateRootId = aggregate_root_id.ToProtobuf(),
             AggregateRootVersion = aggregate_root_version,
+            CurrentAggregateRootVersion = aggregate_root_version,
             Events = { committed_aggregate_event }
         };
 

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_content_is_null.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_content_is_null.cs
@@ -33,6 +33,7 @@ public class and_content_is_null : given.committed_aggregate_events_and_a_conver
             EventSourceId = event_source.Value,
             AggregateRootId = aggregate_root_id.ToProtobuf(),
             AggregateRootVersion = aggregate_root_version,
+            CurrentAggregateRootVersion = aggregate_root_version,
             Events = { committed_aggregate_event }
         };
 

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_content_is_whitespace.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_content_is_whitespace.cs
@@ -34,6 +34,7 @@ public class and_content_is_whitespace : given.committed_aggregate_events_and_a_
             EventSourceId = event_source.Value,
             AggregateRootId = aggregate_root_id.ToProtobuf(),
             AggregateRootVersion = aggregate_root_version,
+            CurrentAggregateRootVersion = aggregate_root_version,
             Events = { committed_aggregate_event }
         };
 

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_event_source_is_a_guid.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_event_source_is_a_guid.cs
@@ -27,6 +27,7 @@ public class and_event_source_is_a_guid : given.committed_aggregate_events_and_a
             EventSourceId = event_source.Value,
             AggregateRootId = aggregate_root_id.ToProtobuf(),
             AggregateRootVersion = aggregate_root_version,
+            CurrentAggregateRootVersion = aggregate_root_version,
             Events = { committed_aggregate_event }
         };
 

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_event_type_is_null.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_event_type_is_null.cs
@@ -34,6 +34,7 @@ public class and_event_type_is_null : given.committed_aggregate_events_and_a_con
             EventSourceId = event_source.Value,
             AggregateRootId = aggregate_root_id.ToProtobuf(),
             AggregateRootVersion = aggregate_root_version,
+            CurrentAggregateRootVersion = aggregate_root_version,
             Events = { committed_aggregate_event }
         };
 

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_execution_context_is_null.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_execution_context_is_null.cs
@@ -34,6 +34,7 @@ public class and_execution_context_is_null : given.committed_aggregate_events_an
             EventSourceId = event_source.Value,
             AggregateRootId = aggregate_root_id.ToProtobuf(),
             AggregateRootVersion = aggregate_root_version,
+            CurrentAggregateRootVersion = aggregate_root_version,
             Events = { committed_aggregate_event }
         };
 

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_occurred_is_null.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_occurred_is_null.cs
@@ -33,6 +33,7 @@ public class and_occurred_is_null : given.committed_aggregate_events_and_a_conve
             EventSourceId = event_source.Value,
             AggregateRootId = aggregate_root_id.ToProtobuf(),
             AggregateRootVersion = aggregate_root_version,
+            CurrentAggregateRootVersion = aggregate_root_version,
             Events = { committed_aggregate_event }
         };
 

--- a/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_second_event_is_invalid.cs
+++ b/Specifications/Events/Store/Converters/for_AggregateEventToSDKConverter/when_converting_committed_aggregate_events/and_second_event_is_invalid.cs
@@ -35,6 +35,7 @@ public class and_second_event_is_invalid : given.committed_aggregate_events_and_
             EventSourceId = event_source.Value,
             AggregateRootId = aggregate_root_id.ToProtobuf(),
             AggregateRootVersion = aggregate_root_version,
+            CurrentAggregateRootVersion = aggregate_root_version,
             Events = { committed_aggregate_event, second_committed_aggregate_event }
         };
 

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.4.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>8.0.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.3</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>7.4.0-treebeard.4</ContractsVersion>
+        <ContractsVersion>7.4.0-treebeard.5</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.4.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>8.0.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.3</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>7.3.0</ContractsVersion>
+        <ContractsVersion>7.4.0-treebeard.0</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.4.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>8.0.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.3</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>7.4.0-treebeard.0</ContractsVersion>
+        <ContractsVersion>7.4.0-treebeard.4</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>6.4.0</AutofacVersion>
         <AutofacExtensionsDependencyInjectionVersion>8.0.0</AutofacExtensionsDependencyInjectionVersion>
         <BaselineTypeDiscoveryVersion>1.1.3</BaselineTypeDiscoveryVersion>
-        <ContractsVersion>7.4.0-treebeard.5</ContractsVersion>
+        <ContractsVersion>7.4.0</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>


### PR DESCRIPTION
## Summary

Adds a new method to the `EventStore` for fetching committed aggregate events filtered by event types. This allows us to change the rehydration of aggregates to be much more effective by just fetching the committed aggregate events for an aggregate that are relevant to the rehydration (meaning that there are an `On` method for that event type). This can have a significant impact on the performance of aggregates that have many events, but few state changes or are completely stateless. 

### Added

- `FetchForAggregate` that takes in a list event types used for filtering
- `FetchStreamForAggregate` fetches a stream of committed aggregate event batches

### Changed

- Rehydration logic of aggregate roots. It now only fetches the committed aggregate events that are relevant
- `AggregateRootVersion` on the `CommittedAggregateEvents` now represents the current aggregate root version of the aggregate root, not the version of the last committed aggregate event
- Minor version of Contracts meaning that this version of the SDK is only compatible with version `>= 8.5.0` of the Runtime


### Fixed

- Some users could experience exceptions when performing actions on aggregate roots that had lots of events or big events due to the protobuf messages being too big. This should be fixed now since the internals of fetching aggregate roots are now implemented using streaming and batching.
