### PR TITLE
Enable dependency injection for aggregate roots

### DIFF
--- a/Samples/Tutorials/Aggregates/Kitchen.cs
+++ b/Samples/Tutorials/Aggregates/Kitchen.cs
@@ -6,19 +6,29 @@ using System;
 using Dolittle.SDK.Aggregates;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Tenancy;
+using Microsoft.Extensions.Logging;
 
 [AggregateRoot("01ad9a9f-711f-47a8-8549-43320f782a1e")]
 public class Kitchen : AggregateRoot
 {
-    readonly SomeGlobalService _globalService;
-    readonly SomeTenantService _tenantService;
+    readonly EventSourceId _eventSource;
+    readonly ILogger<Kitchen> _logger;
     int _ingredients = 2;
+
+    public Kitchen(EventSourceId eventSource, ILogger<Kitchen> logger)
+    {
+        _eventSource = eventSource;
+        _logger = logger;
+    }
 
     public void PrepareDish(string dish, string chef)
     {
-        if (_ingredients <= 0) throw new Exception("We have run out of ingredients, sorry!");
+        if (_ingredients <= 0)
+        {
+            throw new Exception("We have run out of ingredients, sorry!");
+        }
         Apply(new DishPrepared(dish, chef));
-        Console.WriteLine($"Kitchen {EventSourceId} prepared a {dish}, there are {_ingredients} ingredients left.");
+        _logger.LogInformation("Kitchen {EventSourceId} prepared a {Dish}, there are {Ingredients} ingredients left", _eventSource, dish, _ingredients);
     }
 
     void On(DishPrepared @event)

--- a/Samples/Tutorials/Aggregates/Kitchen.cs
+++ b/Samples/Tutorials/Aggregates/Kitchen.cs
@@ -5,16 +5,14 @@
 using System;
 using Dolittle.SDK.Aggregates;
 using Dolittle.SDK.Events;
+using Dolittle.SDK.Tenancy;
 
 [AggregateRoot("01ad9a9f-711f-47a8-8549-43320f782a1e")]
 public class Kitchen : AggregateRoot
 {
+    readonly SomeGlobalService _globalService;
+    readonly SomeTenantService _tenantService;
     int _ingredients = 2;
-
-    public Kitchen(EventSourceId eventSource)
-        : base(eventSource)
-    {
-    }
 
     public void PrepareDish(string dish, string chef)
     {

--- a/Samples/Tutorials/Aggregates/Program.cs
+++ b/Samples/Tutorials/Aggregates/Program.cs
@@ -9,8 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var host = Host.CreateDefaultBuilder()
-    .UseDolittle(configureClientConfiguration: _ => _.WithTenantServices((_, services) => services.AddSingleton<SomeTenantService>()))
-    .ConfigureServices(_ => _.AddSingleton<SomeGlobalService>())
+    .UseDolittle()
     .Build();
 
 await host.StartAsync();
@@ -19,24 +18,7 @@ var client = await host.GetDolittleClient();
 
 await client.Aggregates
     .ForTenant(TenantId.Development)
-    .Get<Kitchen>("Dolittle Tacos4")
+    .Get<Kitchen>("Dolittle Tacos5")
     .Perform(kitchen => kitchen.PrepareDish("Bean Blaster Taco", "Mr. Taco"));
 
 await host.WaitForShutdownAsync();
-
-
-public class SomeGlobalService
-{
-    public void DoStuff() => Console.WriteLine($"Doing stuff");
-}
-public class SomeTenantService
-{
-    readonly TenantId _tenant;
-
-    public SomeTenantService(TenantId tenant)
-    {
-        _tenant = tenant;
-    }
-
-    public void DoStuff() => Console.WriteLine($"Doing stuff for tenant {_tenant}");
-}

--- a/Samples/Tutorials/Aggregates/Program.cs
+++ b/Samples/Tutorials/Aggregates/Program.cs
@@ -18,7 +18,7 @@ var client = await host.GetDolittleClient();
 
 await client.Aggregates
     .ForTenant(TenantId.Development)
-    .Get<Kitchen>("Dolittle Tacos5")
+    .Get<Kitchen>("Dolittle Tacos")
     .Perform(kitchen => kitchen.PrepareDish("Bean Blaster Taco", "Mr. Taco"));
 
 await host.WaitForShutdownAsync();

--- a/Samples/Tutorials/Aggregates/Program.cs
+++ b/Samples/Tutorials/Aggregates/Program.cs
@@ -2,12 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // Sample code for the tutorial at https://dolittle.io/tutorials/getting-started/csharp/
 
+using System;
 using Dolittle.SDK;
 using Dolittle.SDK.Tenancy;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var host = Host.CreateDefaultBuilder()
-    .UseDolittle()
+    .UseDolittle(configureClientConfiguration: _ => _.WithTenantServices((_, services) => services.AddSingleton<SomeTenantService>()))
+    .ConfigureServices(_ => _.AddSingleton<SomeGlobalService>())
     .Build();
 
 await host.StartAsync();
@@ -16,7 +19,24 @@ var client = await host.GetDolittleClient();
 
 await client.Aggregates
     .ForTenant(TenantId.Development)
-    .Get<Kitchen>("Dolittle Tacos")
+    .Get<Kitchen>("Dolittle Tacos4")
     .Perform(kitchen => kitchen.PrepareDish("Bean Blaster Taco", "Mr. Taco"));
 
 await host.WaitForShutdownAsync();
+
+
+public class SomeGlobalService
+{
+    public void DoStuff() => Console.WriteLine($"Doing stuff");
+}
+public class SomeTenantService
+{
+    readonly TenantId _tenant;
+
+    public SomeTenantService(TenantId tenant)
+    {
+        _tenant = tenant;
+    }
+
+    public void DoStuff() => Console.WriteLine($"Doing stuff for tenant {_tenant}");
+}

--- a/Source/Aggregates/AggregateRootOperationFailed.cs
+++ b/Source/Aggregates/AggregateRootOperationFailed.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Events;
+
+namespace Dolittle.SDK.Aggregates;
+
+/// <summary>
+/// Exception that gets thrown when an <see cref="AggregateRootOperations{TAggregate}.Perform(System.Action{TAggregate},System.Threading.CancellationToken)"/> failed. 
+/// </summary>
+public class AggregateRootOperationFailed : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AggregateRootOperationFailed"/> class.
+    /// </summary>
+    /// <param name="aggregateRootType">The <see cref="Type"/> of the <see cref="AggregateRoot"/>.</param>
+    /// <param name="eventSource">The <see cref="EventSourceId"/> of the aggregate.</param>
+    /// <param name="error">The inner <see cref="Exception"/> reason for failure.</param>
+    public AggregateRootOperationFailed(Type aggregateRootType, EventSourceId eventSource, Exception error)
+        : base($"Failed to perform operation on {aggregateRootType} aggregate with event source {eventSource}", error)
+    {
+    }
+}

--- a/Source/Aggregates/AggregateRootOperations.cs
+++ b/Source/Aggregates/AggregateRootOperations.cs
@@ -26,6 +26,7 @@ public class AggregateRootOperations<TAggregate> : IAggregateRootOperations<TAgg
     readonly IEventStore _eventStore;
     readonly IEventTypes _eventTypes;
     readonly IAggregateRoots _aggregateRoots;
+    readonly IServiceProvider _serviceProvider;
     readonly ILogger _logger;
 
     /// <summary>
@@ -35,18 +36,20 @@ public class AggregateRootOperations<TAggregate> : IAggregateRootOperations<TAgg
     /// <param name="eventStore">The <see cref="IEventStore" /> used for committing the <see cref="UncommittedAggregateEvents" /> when actions are performed on the <typeparamref name="TAggregate">aggregate</typeparamref>. </param>
     /// <param name="eventTypes">The <see cref="IEventTypes"/>.</param>
     /// <param name="aggregateRoots">The <see cref="IAggregateRoots"/> used for getting an aggregate root instance.</param>
+    /// <param name="serviceProvider">The tenant scoped <see cref="IServiceProvider"/>.</param>
     /// <param name="logger">The <see cref="ILogger" />.</param>
-    public AggregateRootOperations(EventSourceId eventSourceId, IEventStore eventStore, IEventTypes eventTypes, IAggregateRoots aggregateRoots, ILogger logger)
+    public AggregateRootOperations(EventSourceId eventSourceId, IEventStore eventStore, IEventTypes eventTypes, IAggregateRoots aggregateRoots, IServiceProvider serviceProvider, ILogger logger)
     {
         _eventSourceId = eventSourceId;
         _eventTypes = eventTypes;
         _eventStore = eventStore;
         _aggregateRoots = aggregateRoots;
+        _serviceProvider = serviceProvider;
         _logger = logger;
     }
 
     /// <inheritdoc/>
-    public Task Perform(Action<TAggregate> method, CancellationToken cancellationToken)
+    public Task Perform(Action<TAggregate> method, CancellationToken cancellationToken = default)
         => Perform(
             aggregate =>
             {
@@ -56,16 +59,16 @@ public class AggregateRootOperations<TAggregate> : IAggregateRootOperations<TAgg
             cancellationToken);
 
     /// <inheritdoc/>
-    public async Task Perform(Func<TAggregate, Task> method, CancellationToken cancellationToken)
+    public async Task Perform(Func<TAggregate, Task> method, CancellationToken cancellationToken = default)
     {
         using var activity = Tracing.ActivitySource.StartActivity()
             ?.Tag(_eventSourceId);
 
         try
         {
-            if (!TryGetAggregateRoot(_eventSourceId, out var aggregateRoot, out var exception))
+            if (!TryGetAggregateRoot(out var aggregateRoot, out var exception))
             {
-                throw new CouldNotGetAggregateRoot(typeof(TAggregate), _eventSourceId, exception.Message);
+                throw new CouldNotGetAggregateRoot(typeof(TAggregate), _eventSourceId, exception);
             }
 
             var aggregateRootId = aggregateRoot.GetAggregateRootId();
@@ -85,9 +88,9 @@ public class AggregateRootOperations<TAggregate> : IAggregateRootOperations<TAgg
         }
     }
 
-    bool TryGetAggregateRoot(EventSourceId eventSourceId, out TAggregate aggregateRoot, out Exception exception)
+    bool TryGetAggregateRoot(out TAggregate aggregateRoot, out Exception exception)
     {
-        var getAggregateRoot = _aggregateRoots.TryGet<TAggregate>(eventSourceId);
+        var getAggregateRoot = _aggregateRoots.TryGet<TAggregate>(_eventSourceId, _serviceProvider);
         aggregateRoot = getAggregateRoot.Result;
         exception = getAggregateRoot.Exception;
         return getAggregateRoot.Success;

--- a/Source/Aggregates/AggregateRootOperations.cs
+++ b/Source/Aggregates/AggregateRootOperations.cs
@@ -84,7 +84,7 @@ public class AggregateRootOperations<TAggregate> : IAggregateRootOperations<TAgg
         catch (Exception e)
         {
             activity?.RecordError(e);
-            throw;
+            throw new AggregateRootOperationFailed(typeof(TAggregate), _eventSourceId, e);
         }
     }
 

--- a/Source/Aggregates/Builders/Aggregates.cs
+++ b/Source/Aggregates/Builders/Aggregates.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Dolittle.SDK.Aggregates.Internal;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Events.Store;
+using Dolittle.SDK.Tenancy;
 using Microsoft.Extensions.Logging;
 
 namespace Dolittle.SDK.Aggregates.Builders;
@@ -16,6 +18,7 @@ public class Aggregates : IAggregates
     readonly IEventStore _eventStore;
     readonly IEventTypes _eventTypes;
     readonly IAggregateRoots _aggregateRoots;
+    readonly IServiceProvider _serviceProvider;
     readonly ILoggerFactory _loggerFactory;
 
     /// <summary>
@@ -24,12 +27,14 @@ public class Aggregates : IAggregates
     /// <param name="eventStore">The <see cref="IEventStore"/>.</param>
     /// <param name="eventTypes">The <see cref="IEventTypes"/>.</param>
     /// <param name="aggregateRoots">The <see cref="IAggregateRoots"/>.</param>
+    /// <param name="serviceProvider">The tenant scoped <see cref="IServiceProvider"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
-    public Aggregates(IEventStore eventStore, IEventTypes eventTypes, IAggregateRoots aggregateRoots, ILoggerFactory loggerFactory)
+    public Aggregates(IEventStore eventStore, IEventTypes eventTypes, IAggregateRoots aggregateRoots, IServiceProvider serviceProvider, ILoggerFactory loggerFactory)
     {
         _eventStore = eventStore;
         _eventTypes = eventTypes;
         _aggregateRoots = aggregateRoots;
+        _serviceProvider = serviceProvider;
         _loggerFactory = loggerFactory;
     }
 
@@ -41,6 +46,7 @@ public class Aggregates : IAggregates
             _eventStore,
             _eventTypes,
             _aggregateRoots,
+            _serviceProvider,
             _loggerFactory.CreateLogger<AggregateRootOperations<TAggregateRoot>>());
 
     /// <inheritdoc />

--- a/Source/Aggregates/Builders/AggregatesBuilder.cs
+++ b/Source/Aggregates/Builders/AggregatesBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Dolittle.SDK.Aggregates.Internal;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Events.Store.Builders;
@@ -16,6 +17,7 @@ public class AggregatesBuilder : IAggregatesBuilder
 {
     readonly IEventTypes _eventTypes;
     readonly IAggregateRoots _aggregateRoots;
+    readonly Func<TenantId, IServiceProvider> _getServiceProvider;
     readonly IEventStoreBuilder _eventStoreBuilder;
     readonly ILoggerFactory _loggerFactory;
 
@@ -25,16 +27,18 @@ public class AggregatesBuilder : IAggregatesBuilder
     /// <param name="eventStoreBuilder">The <see cref="IEventStoreBuilder" />.</param>
     /// <param name="eventTypes">The <see cref="IEventTypes" />.</param>
     /// <param name="aggregateRoots">The <see cref="IAggregateRoots"/>.</param>
+    /// <param name="getServiceProvider">The <see cref="Func{TResult}"/> for getting the tenant scoped <see cref="IServiceProvider"/> for a <see cref="TenantId"/>.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory" />.</param>
-    public AggregatesBuilder(IEventStoreBuilder eventStoreBuilder, IEventTypes eventTypes, IAggregateRoots aggregateRoots, ILoggerFactory loggerFactory)
+    public AggregatesBuilder(IEventStoreBuilder eventStoreBuilder, IEventTypes eventTypes, IAggregateRoots aggregateRoots, Func<TenantId, IServiceProvider> getServiceProvider, ILoggerFactory loggerFactory)
     {
         _eventTypes = eventTypes;
         _aggregateRoots = aggregateRoots;
+        _getServiceProvider = getServiceProvider;
         _eventStoreBuilder = eventStoreBuilder;
         _loggerFactory = loggerFactory;
     }
 
     /// <inheritdoc />
     public IAggregates ForTenant(TenantId tenant)
-        => new Aggregates(_eventStoreBuilder.ForTenant(tenant), _eventTypes, _aggregateRoots, _loggerFactory);
+        => new Aggregates(_eventStoreBuilder.ForTenant(tenant), _eventTypes, _aggregateRoots, _getServiceProvider(tenant), _loggerFactory);
 }

--- a/Source/Aggregates/CouldNotCreateAggregateRootInstance.cs
+++ b/Source/Aggregates/CouldNotCreateAggregateRootInstance.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Dolittle.SDK.Events;
 
 namespace Dolittle.SDK.Aggregates;
 
@@ -14,8 +15,8 @@ public class CouldNotCreateAggregateRootInstance : Exception
     /// Initializes a new instance of the <see cref="CouldNotCreateAggregateRootInstance"/> class.
     /// </summary>
     /// <param name="type">The <see cref="Type" /> of the aggregate root that could not be instantiated.</param>
-    public CouldNotCreateAggregateRootInstance(Type type)
-        : base($"Could not create an instance of aggregate root {type}")
+    public CouldNotCreateAggregateRootInstance(Type type, EventSourceId eventSource, Exception error)
+        : base($"Could not create an instance of aggregate root {type} with event source {eventSource}", error)
     {
     }
 }

--- a/Source/Aggregates/CouldNotGetAggregateRoot.cs
+++ b/Source/Aggregates/CouldNotGetAggregateRoot.cs
@@ -16,9 +16,9 @@ public class CouldNotGetAggregateRoot : Exception
     /// </summary>
     /// <param name="type">The <see cref="Type" /> of the aggregate root.</param>
     /// <param name="eventSourceId">The <see cref="EventSourceId" />.</param>
-    /// <param name="reason">The reason for why the aggregate root could not be retrieved.</param>
-    public CouldNotGetAggregateRoot(Type type, EventSourceId eventSourceId, string reason)
-        : base($"Could not get aggregate root of type {type} with event source id {eventSourceId}. {reason}")
+    /// <param name="error">The inner error <see cref="Exception"/>.</param>
+    public CouldNotGetAggregateRoot(Type type, EventSourceId eventSourceId, Exception error)
+        : base($"Could not get aggregate root of type {type} with event source id {eventSourceId}", error)
     {
     }
 }

--- a/Source/Aggregates/EventSourceIdOnAggregateRootNotReady.cs
+++ b/Source/Aggregates/EventSourceIdOnAggregateRootNotReady.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Events;
+
+namespace Dolittle.SDK.Aggregates;
+
+/// <summary>
+/// Exception that gets thrown when trying to get the <see cref="EventSourceId"/> for an <see cref="AggregateRoot"/> where the value has not been set yet.
+/// </summary>
+public class EventSourceIdOnAggregateRootNotReady : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventSourceIdOnAggregateRootNotReady"/> class.
+    /// </summary>
+    /// <param name="aggregateRootType">The <see cref="Type"/> of the aggregate root.</param>
+    public EventSourceIdOnAggregateRootNotReady(Type aggregateRootType)
+        : base($"Event Source has not yet been set on the {aggregateRootType} aggregate root instance. This typically happens when trying to use the {nameof(AggregateRoot.EventSourceId)} property in the constructor." +
+            $" If this is important then all you need to do is to include in the public constructor a parameter with the {typeof(EventSourceId)} type and use that in the bast constructor, then the {nameof(AggregateRoot.EventSourceId)} property will be accessible in the constructor.")
+    {}
+}

--- a/Source/Aggregates/Internal/EventSourceIdOnAggregateRootNotReady.cs
+++ b/Source/Aggregates/Internal/EventSourceIdOnAggregateRootNotReady.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Events;
+
+namespace Dolittle.SDK.Aggregates.Internal;
+
+/// <summary>
+/// Exception that gets thrown when trying to change the <see cref="EventSourceId"/> for an <see cref="AggregateRoot"/>.
+/// </summary>
+public class CannotChangeEventSourceIdForAggregateRoot : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CannotChangeEventSourceIdForAggregateRoot"/> class.
+    /// </summary>
+    /// <param name="aggregateRootType">The <see cref="Type"/> of the aggregate root.</param>
+    /// <param name="eventSourceId">The original <see cref="EventSourceId"/>.</param>
+    /// <param name="newEventSourceId">The new <see cref="EventSourceId"/>.</param>
+    public CannotChangeEventSourceIdForAggregateRoot(Type aggregateRootType, EventSourceId eventSourceId, EventSourceId newEventSourceId)
+        : base($"Internal error: Cannot change Event Source on the {aggregateRootType} aggregate root instance from {eventSourceId} to {newEventSourceId}. Changing event source id should not happen and is likely due to a mistake.")
+    {}
+}

--- a/Source/Aggregates/Internal/IAggregateRoots.cs
+++ b/Source/Aggregates/Internal/IAggregateRoots.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Dolittle.SDK.Async;
 using Dolittle.SDK.Events;
 
@@ -15,8 +16,9 @@ public interface IAggregateRoots
     /// Tries to get an <typeparamref name="TAggregate"/> instance for the specified <see cref="EventSourceId"/>.
     /// </summary>
     /// <param name="eventSourceId">The <see cref="EventSourceId"/> of the aggregate root instance to create.</param>
+    /// <param name="serviceProvider">The tenant scoped <see cref="IServiceProvider"/>.</param>
     /// <typeparam name="TAggregate"><see cref="AggregateRoot"/> type.</typeparam>
     /// <returns>A <see cref="Try{TResult}"/> with the <typeparamref name="TAggregate"/>.</returns>
-    Try<TAggregate> TryGet<TAggregate>(EventSourceId eventSourceId)
+    Try<TAggregate> TryGet<TAggregate>(EventSourceId eventSourceId, IServiceProvider serviceProvider)
         where TAggregate : AggregateRoot;
 }

--- a/Source/SDK/DolittleClient.cs
+++ b/Source/SDK/DolittleClient.cs
@@ -336,6 +336,7 @@ public class DolittleClient : IDisposable, IDolittleClient
             _eventStore,
             _unregisteredEventTypes,
             new AggregateRoots(loggerFactory.CreateLogger<AggregateRoots>()),
+            tenant => Services.ForTenant(tenant),
             loggerFactory);
         EventHorizons = new EventHorizons(
             methodCaller,


### PR DESCRIPTION
## Summary

Enables dependency injection for aggregate roots

### Added

- Tenant scoped dependencies will now be injected in the aggregate roots

### Deprecated

- AggregateRoot base constructor with event source id is no longer necessary
