### PR TITLE
Additional tracing

### DIFF
--- a/Source/Aggregates/AggregateRootOperations.cs
+++ b/Source/Aggregates/AggregateRootOperations.cs
@@ -61,7 +61,7 @@ public class AggregateRootOperations<TAggregate> : IAggregateRootOperations<TAgg
     /// <inheritdoc/>
     public async Task Perform(Func<TAggregate, Task> method, CancellationToken cancellationToken = default)
     {
-        using var activity = Tracing.ActivitySource.StartActivity()
+        using var activity = Tracing.ActivitySource.StartActivity($"{typeof(TAggregate).Name}.Perform")
             ?.Tag(_eventSourceId);
 
         try

--- a/Source/Diagnostics.OpenTelemetry/Diagnostics.OpenTelemetry.csproj
+++ b/Source/Diagnostics.OpenTelemetry/Diagnostics.OpenTelemetry.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="../../default.props" />
+    <Import Project="../../default.props"/>
 
     <PropertyGroup>
         <AssemblyName>Dolittle.SDK.Diagnostics.OpenTelemetry</AssemblyName>
@@ -8,16 +8,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="../Diagnostics/Diagnostics.csproj" />
+        <ProjectReference Include="../Diagnostics/Diagnostics.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.3.0-rc.2" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.4" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1"/>
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.3.0-rc.2"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.4"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4"/>
+        <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="$(MongoDBOpenTelemetryVersion)"/>
     </ItemGroup>
 
 </Project>

--- a/Source/Diagnostics.OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/Source/Diagnostics.OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -14,7 +14,7 @@ using OpenTelemetry.Trace;
 namespace Dolittle.SDK.Diagnostics.OpenTelemetry;
 
 /// <summary>
-/// Helper class to simplify setting up logs & traces via OTLP
+/// Helper class to simplify setting up logs and traces via OTLP
 /// </summary>
 public static class OpenTelemetryConfigurationExtensions
 {
@@ -88,6 +88,8 @@ public static class OpenTelemetryConfigurationExtensions
             {
                 builder.SetResourceBuilder(resourceBuilder)
                     .AddDolittleInstrumentation()
+                    .AddAspNetCoreInstrumentation()
+                    .AddMongoDBInstrumentation()
                     .AddOtlpExporter(ConfigureOtlpExporter(otlpEndpoint));
                 configure?.Invoke(builder);
             }));

--- a/Source/Diagnostics.OpenTelemetry/OpenTelemetrySettings.cs
+++ b/Source/Diagnostics.OpenTelemetry/OpenTelemetrySettings.cs
@@ -7,6 +7,9 @@ using OpenTelemetry.Trace;
 
 namespace Dolittle.SDK.Diagnostics.OpenTelemetry;
 
+/// <summary>
+/// Configuration options for OpenTelemetry tracing and logging
+/// </summary>
 public record OpenTelemetrySettings
 {
     /// <summary>

--- a/Source/Events.Handling/EventHandler.cs
+++ b/Source/Events.Handling/EventHandler.cs
@@ -80,7 +80,7 @@ public class EventHandler : IEventHandler
     /// <inheritdoc/>
     public async Task Handle(object @event, EventType eventType, EventContext context, IServiceProvider serviceProvider, CancellationToken cancellation)
     {
-        using var activity = context.CommittedExecutionContext.StartChildActivity("Handle " + @event.GetType().Name)
+        using var activity = context.CommittedExecutionContext.StartChildActivity($"{(HasAlias ? Alias.Value + "." : "")}Handle {@event.GetType().Name}")
             ?.Tag(eventType);
 
         try

--- a/Source/Events/ActivityExtensions.cs
+++ b/Source/Events/ActivityExtensions.cs
@@ -26,7 +26,7 @@ public static class ActivityExtensions
         activity.SetTag(EventType, eventType.Id.Value);
         if (eventType.HasAlias)
         {
-            activity.SetTag(EventTypeAlias, eventType.Alias.Value);
+            activity.SetTag(EventTypeAlias, eventType.Alias!.Value);
         }
 
         return activity;

--- a/Source/Events/Builders/EventTypesBuilder.cs
+++ b/Source/Events/Builders/EventTypesBuilder.cs
@@ -39,6 +39,10 @@ public class EventTypesBuilder : IEventTypesBuilder
     public IEventTypesBuilder Associate(Type type, EventType eventType)
     {
         Register(type);
+        if (!eventType.HasAlias)
+        {
+            eventType = new EventType(eventType.Id, eventType.Generation, type.Name);
+        }
         _modelBuilder.BindIdentifierToType<EventType, EventTypeId>(eventType, type);
         return this;
     }

--- a/Source/Resources/MongoDB/Internal/MongoDBResource.cs
+++ b/Source/Resources/MongoDB/Internal/MongoDBResource.cs
@@ -4,6 +4,7 @@
 using System;
 using Dolittle.Runtime.Resources.Contracts;
 using MongoDB.Driver;
+using MongoDB.Driver.Core.Extensions.DiagnosticSources;
 
 namespace Dolittle.SDK.Resources.MongoDB.Internal;
 
@@ -23,6 +24,7 @@ public class MongoDBResource : IMongoDBResource
     {
         _mongoUrl = MongoUrl.Create(runtimeMongoDBResponse.ConnectionString);
         var clientSettings = MongoClientSettings.FromUrl(_mongoUrl);
+        clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber());
         _mongoClient = new MongoClient(clientSettings.Freeze());
     }
 

--- a/Source/Resources/Resources.csproj
+++ b/Source/Resources/Resources.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
+        <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="$(MongoDBOpenTelemetryVersion)" />
         <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
     </ItemGroup>
 

--- a/versions.props
+++ b/versions.props
@@ -12,6 +12,7 @@
         <ProtobufVersion>3.18.1</ProtobufVersion>
         <GrpcVersion>2.43.0</GrpcVersion>
         <MongoDBDriverVersion>2.13.2</MongoDBDriverVersion>
+        <MongoDBOpenTelemetryVersion>1.0.0</MongoDBOpenTelemetryVersion>
         <NewtonsoftVersion>12.0.3</NewtonsoftVersion>
         <SystemImmutableVersion>1.7.1</SystemImmutableVersion>
         <SystemLinqAsyncVersion>5.1.0</SystemLinqAsyncVersion>


### PR DESCRIPTION
## Summary

Adds both MongoDB and AspNetCore as enabled by default when the runtime is configured for tracing.

### Added
- MongoDB OpenTelemetry instrumentation, 
- AspNetCore OpenTelemetry instrumentation enabled by default
- Automatic aliasing of registered events