### PR TITLE
Made aggregate idle timeouts configurable

### DIFF
--- a/Samples/Environment/docker-compose.yml
+++ b/Samples/Environment/docker-compose.yml
@@ -4,30 +4,34 @@ services:
     image: dolittle/mongodb
     hostname: mongo
     volumes:
-      - ${PWD}/data:/data
+      - ./data:/data
     ports:
       - 27017:27017
  
   runtime-basic:
-    image: dolittle/runtime:5.3.5
+    image: dolittle/runtime:8.7.2
+    environment:
+      DOLITTLE__RUNTIME__EVENTSTORE__BACKWARDSCOMPATIBILITY__VERSION: "V7"
     volumes:
-      - ${PWD}/resources-basic.json:/app/.dolittle/resources.json
-      - ${PWD}/tenants.json:/app/.dolittle/tenants.json
-      - ${PWD}/microservices.json:/app/.dolittle/microservices.json
-      - ${PWD}/event-horizon-consents.json:/app/.dolittle/event-horizon-consents.json
-      - ${PWD}/appsettings.json:/app/appsettings.json
+      - ./resources-basic.json:/app/.dolittle/resources.json
+      - ./tenants.json:/app/.dolittle/tenants.json
+      - ./microservices.json:/app/.dolittle/microservices.json
+      - ./event-horizon-consents.json:/app/.dolittle/event-horizon-consents.json
+      - ./appsettings.json:/app/appsettings.json
     ports:
       - 9700:9700
       - 50052:50052
       - 50053:50053
 
   runtime-eventhorizon:
-    image: dolittle/runtime:5.3.5
+    image: dolittle/runtime:8.7.2
+    environment:
+      DOLITTLE__RUNTIME__EVENTSTORE__BACKWARDSCOMPATIBILITY__VERSION: "V7"
     volumes:
-      - ${PWD}/resources-eventhorizon.json:/app/.dolittle/resources.json
-      - ${PWD}/tenants.json:/app/.dolittle/tenants.json
-      - ${PWD}/microservices.json:/app/.dolittle/microservices.json
-      - ${PWD}/appsettings.json:/app/appsettings.json
+      - ./resources-eventhorizon.json:/app/.dolittle/resources.json
+      - ./tenants.json:/app/.dolittle/tenants.json
+      - ./microservices.json:/app/.dolittle/microservices.json
+      - ./appsettings.json:/app/appsettings.json
     ports:
       - 9701:9700
       - 50054:50052

--- a/Samples/Tutorials/Aggregates/Program.cs
+++ b/Samples/Tutorials/Aggregates/Program.cs
@@ -15,7 +15,7 @@ await host.StartAsync();
 var client = await host.GetDolittleClient();
 
 await client.Aggregates
-    .ForTenant(TenantId.System)
+    .ForTenant(TenantId.Development)
     .Get<Kitchen>("Dolittle Tacos")
     .Perform(kitchen => kitchen.PrepareDish("Bean Blaster Taco", "Mr. Taco"));
 

--- a/Samples/Tutorials/Aggregates/appsettings.json
+++ b/Samples/Tutorials/Aggregates/appsettings.json
@@ -5,7 +5,8 @@
             "Port": 50053
         },
         "HeadVersion": "1.0.0",
-        "PingInterval": 5
+        "PingInterval": 5,
+        "AggregateIdleTimout": 5
     },
     "Logging": {
         "LogLevel": {

--- a/Source/Aggregates/Actors/AggregateClusterKindFactory.cs
+++ b/Source/Aggregates/Actors/AggregateClusterKindFactory.cs
@@ -21,14 +21,15 @@ static class AggregateClusterKindFactory
 
 static class AggregateClusterKindFactory<TAggregate> where TAggregate : AggregateRoot
 {
+    // ReSharper disable once UnusedMember.Global - Called by reflection
     public static ClusterKind CreateKind(IServiceProvider serviceProvider)
     {
         var aggregateRootType = AggregateRootMetadata<TAggregate>.AggregateRootType ?? throw new MissingAggregateRootAttribute(typeof(TAggregate));
-
         var providerForTenant = serviceProvider.GetRequiredService<GetServiceProviderForTenant>();
         var logger = serviceProvider.GetRequiredService<ILogger<AggregateActor<TAggregate>>>();
+        var idleUnloadTimeout = serviceProvider.GetRequiredService<AggregateUnloadTimeout>()();
 
         return new ClusterKind(aggregateRootType.Id.Value.ToString(),
-            Props.FromProducer(() => new AggregateActor<TAggregate>(providerForTenant, logger)));
+            Props.FromProducer(() => new AggregateActor<TAggregate>(providerForTenant, logger, idleUnloadTimeout)));
     }
 }

--- a/Source/SDK/Builders/IConfigurationBuilder.cs
+++ b/Source/SDK/Builders/IConfigurationBuilder.cs
@@ -30,6 +30,7 @@ public interface IConfigurationBuilder
     /// <returns>the client configuration builder for continuation.</returns>
     /// <remarks>If not specified, host 'localhost' and port 50053 will be used.</remarks>
     public IConfigurationBuilder WithRuntimeOn(string host, ushort port);
+
     /// <summary>
     /// Sets the <see cref="ILoggerFactory"/> to use for creating instances of <see cref="ILogger"/> for the client configuration.
     /// </summary>
@@ -58,6 +59,13 @@ public interface IConfigurationBuilder
     /// <param name="interval">The ping interval.</param>
     /// <returns>the client configuration builder for continuation.</returns>
     public IConfigurationBuilder WithPingInterval(TimeSpan interval);
+
+    /// <summary>
+    /// Sets how long should the aggregates be kept in memory when not in use.
+    /// </summary>
+    /// <param name="timeout">Duration to keep aggregates in memory when idle. -1 ms to never unload them.</param>
+    /// <returns></returns>
+    public IConfigurationBuilder WithAggregateIdleTimout(TimeSpan timeout);
 
     /// <summary>
     /// Configures the root <see cref="IServiceProvider"/> for the <see cref="IDolittleClient"/>.

--- a/Source/SDK/Configurations/Dolittle.cs
+++ b/Source/SDK/Configurations/Dolittle.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #nullable enable
+using System;
+
 namespace Dolittle.SDK.Configurations;
 
 /// <summary>
@@ -23,6 +25,11 @@ public class Dolittle
     /// The ping interval to use for reverse call clients.
     /// </summary>
     public ushort? PingInterval { get; set; }
+
+    /// <summary>
+    /// How many seconds should the aggregates be kept in memory when not in use. -1 is forever, 0 will instantly remove them. 
+    /// </summary>
+    public int? AggregateIdleTimout { get; set; }
 
     /// <summary>
     /// The OpenTelemetry configuration.

--- a/Source/SDK/Proto/ServiceCollectionExtensions.cs
+++ b/Source/SDK/Proto/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Dolittle.SDK.Aggregates.Actors;
+using Dolittle.SDK.Builders;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -32,6 +33,13 @@ static class ServiceCollectionExtensions
                     await client.Connected;
                     return client.Services.ForTenant(tenantId);
                 };
+            })
+            .AddSingleton<AggregateUnloadTimeout>(sp =>
+            {
+                var dolittleClientConfiguration = sp.GetRequiredService<DolittleClientConfiguration>();
+                var timeout = dolittleClientConfiguration.AggregateIdleTimeout;
+
+                return () => timeout;
             });
     }
 


### PR DESCRIPTION
## Summary

Adds a configuration option for `AggregateIdleTimeout` Allows for instant (0), Never, (-1) or a number of seconds before activated aggregate roots are removed from memory.

Configure via `IConfigurationBuilder.WithAggregateIdleTimout` or `Dolittle__AggregateIdleTimout`