### PR TITLE
 Dolittle domain specific Analyzers / Codefixes

### DIFF
--- a/.github/workflows/dotnet-library.yml
+++ b/.github/workflows/dotnet-library.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Setup .Net
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "7.0.x"
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Setup dotCover
         run: dotnet tool install JetBrains.dotCover.GlobalTool -g
       - name: Setup report generator

--- a/.github/workflows/dotnet-library.yml
+++ b/.github/workflows/dotnet-library.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup .Net
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             6.0.x

--- a/DotNET.SDK.sln
+++ b/DotNET.SDK.sln
@@ -122,6 +122,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Meta", "Meta", "{8E6E3E7B-E
 		versions.props = versions.props
 		default.props = default.props
 		tests.props = tests.props
+		base.props = base.props
+		netstandard.props = netstandard.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{9A48B407-5649-44A1-9433-04CCD42F48E5}"
@@ -136,6 +138,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\dotnet-library.yml = .github\workflows\dotnet-library.yml
 		.github\workflows\ms-teams-release.yml = .github\workflows\ms-teams-release.yml
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Analyzers", "Source\Analyzers\Analyzers.csproj", "{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Analyzers", "Tests\Analyzers\Analyzers.csproj", "{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -762,6 +768,30 @@ Global
 		{894F1EAC-4815-4B88-849A-BE09AC01426F}.Release|x64.Build.0 = Release|Any CPU
 		{894F1EAC-4815-4B88-849A-BE09AC01426F}.Release|x86.ActiveCfg = Release|Any CPU
 		{894F1EAC-4815-4B88-849A-BE09AC01426F}.Release|x86.Build.0 = Release|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Debug|x64.Build.0 = Debug|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Debug|x86.Build.0 = Debug|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Release|x64.Build.0 = Release|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80}.Release|x86.Build.0 = Release|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Debug|x64.Build.0 = Debug|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Debug|x86.Build.0 = Debug|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Release|x64.ActiveCfg = Release|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Release|x64.Build.0 = Release|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Release|x86.ActiveCfg = Release|Any CPU
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CCA92423-6099-4712-8599-46426D7895BC} = {4A67BEB1-4496-4C90-96C2-4D6E518C84C5}
@@ -817,5 +847,7 @@ Global
 		{9A48B407-5649-44A1-9433-04CCD42F48E5} = {8E6E3E7B-EF5C-4AEB-919B-FED3DB5F3A73}
 		{257B583D-D4AC-4E78-B010-E1442BA778BF} = {9A48B407-5649-44A1-9433-04CCD42F48E5}
 		{894F1EAC-4815-4B88-849A-BE09AC01426F} = {E1103442-E3E5-43AE-B5B5-9F1965309E24}
+		{AA9DA7EB-9DEA-4AA4-B252-6E00A50F9D80} = {F02DF920-7E63-4C4B-8494-8D98C34E27EF}
+		{2B0ACA4A-11D4-4B1D-A3E2-267565619CAD} = {E1103442-E3E5-43AE-B5B5-9F1965309E24}
 	EndGlobalSection
 EndGlobal

--- a/Source/Aggregates/EventSourceIdOnAggregateRootNotReady.cs
+++ b/Source/Aggregates/EventSourceIdOnAggregateRootNotReady.cs
@@ -15,8 +15,11 @@ public class EventSourceIdOnAggregateRootNotReady : Exception
     /// Initializes a new instance of the <see cref="EventSourceIdOnAggregateRootNotReady"/> class.
     /// </summary>
     /// <param name="aggregateRootType">The <see cref="Type"/> of the aggregate root.</param>
+#pragma warning disable CS0618
     public EventSourceIdOnAggregateRootNotReady(Type aggregateRootType)
         : base($"Event Source has not yet been set on the {aggregateRootType} aggregate root instance. This typically happens when trying to use the {nameof(AggregateRoot.EventSourceId)} property in the constructor." +
             $" If this is important then all you need to do is to include in the public constructor a parameter with the {typeof(EventSourceId)} type and use that in the bast constructor, then the {nameof(AggregateRoot.EventSourceId)} property will be accessible in the constructor.")
-    {}
+    {
+    }
 }
+#pragma warning restore CS0618

--- a/Source/Aggregates/Internal/AggregateRootMetadata.cs
+++ b/Source/Aggregates/Internal/AggregateRootMetadata.cs
@@ -38,7 +38,6 @@ static class AggregateRootMetadata<TAggregateRoot>
     /// <summary>
     /// Gets the <see cref="AggregateRootId" /> of an <see cref="AggregateRoot" />.
     /// </summary>
-    /// <param name="aggregateRoot">The <see cref="AggregateRoot" />.</param>
     /// <returns>The <see cref="AggregateRootId" />.</returns>
     public static AggregateRootId GetAggregateRootId()
     {
@@ -53,7 +52,6 @@ static class AggregateRootMetadata<TAggregateRoot>
     /// <summary>
     /// Gets the <see cref="AggregateRootId" /> of an <see cref="AggregateRoot" />.
     /// </summary>
-    /// <param name="aggregateRoot">The <see cref="AggregateRoot" />.</param>
     /// <returns>The <see cref="AggregateRootId" />.</returns>
     static AggregateRootType? GetAggregateRootType()
     {

--- a/Source/Aggregates/InternalsVisibleTo.cs
+++ b/Source/Aggregates/InternalsVisibleTo.cs
@@ -4,4 +4,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly:InternalsVisibleTo("Dolittle.SDK")]
-[assembly:InternalsVisibleTo("Aggregates")]
+[assembly:InternalsVisibleTo("Dolittle.SDK.Aggregates.Tests")]

--- a/Source/Analyzers/Analyzers.csproj
+++ b/Source/Analyzers/Analyzers.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="../../netstandard.props" />
+
+    <PropertyGroup>
+        <AssemblyName>Dolittle.SDK.Analyzers</AssemblyName>
+        <RootNamespace>Dolittle.SDK.Analyzers</RootNamespace>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" PrivateAssets="all" />
+        <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Update="tools\*.ps1" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="" />
+        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    </ItemGroup>
+
+</Project>

--- a/Source/Analyzers/AnnotationIdentityAnalyzer.cs
+++ b/Source/Analyzers/AnnotationIdentityAnalyzer.cs
@@ -11,12 +11,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Dolittle.SDK.Analyzers;
 
 /// <summary>
-/// Analyzer for reporting code block diagnostics.
-/// It reports diagnostics for all redundant methods which have an empty method body and are not virtual/override.
+/// Annotation analyzer for Dolittle SDK.
+/// Ensures that all identities are valid Guids
 /// </summary>
-/// <remarks>
-/// For analyzers that requires analyzing symbols or syntax nodes across a code block, see <see cref="CodeBlockStartedAnalyzer"/>.
-/// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AnnotationIdentityAnalyzer : DiagnosticAnalyzer
 {

--- a/Source/Analyzers/AnnotationIdentityAnalyzer.cs
+++ b/Source/Analyzers/AnnotationIdentityAnalyzer.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Dolittle.SDK.Analyzers;
+
+/// <summary>
+/// Analyzer for reporting code block diagnostics.
+/// It reports diagnostics for all redundant methods which have an empty method body and are not virtual/override.
+/// </summary>
+/// <remarks>
+/// For analyzers that requires analyzing symbols or syntax nodes across a code block, see <see cref="CodeBlockStartedAnalyzer"/>.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AnnotationIdentityAnalyzer : DiagnosticAnalyzer
+{
+    const string Title = "Invalid identity in attribute";
+    const string MessageFormat = "Attribute '{0}' {1}: '{2}' is not a valid Guid";
+    const string Description = "Add a Guid identity";
+
+
+    internal static readonly DiagnosticDescriptor InvalidIdentityRule =
+        new(
+            DiagnosticIds.AnnotationInvalidIdentityRuleId,
+            Title,
+            MessageFormat,
+            DiagnosticCategories.Sdk,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(InvalidIdentityRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(CheckHasIdentity, ImmutableArray.Create(SyntaxKind.Attribute));
+    }
+
+    void CheckHasIdentity(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not AttributeSyntax attribute) return;
+        if (context.SemanticModel.GetSymbolInfo(attribute).Symbol is not IMethodSymbol symbol) return;
+        if (!symbol.IsDolittleType()) return;
+
+
+        switch (symbol.ToDisplayString())
+        {
+            case "Dolittle.SDK.Events.EventTypeAttribute.EventTypeAttribute(string, uint, string)":
+            case "Dolittle.SDK.Events.Handling.EventHandlerAttribute.EventHandlerAttribute(string, bool, string, string)":
+            case "Dolittle.SDK.Aggregates.AggregateRootAttribute.AggregateRootAttribute(string, string)":
+            case "Dolittle.SDK.Projections.ProjectionAttribute.ProjectionAttribute(string, string, string)":
+            case "Dolittle.SDK.Embeddings.EmbeddingAttribute.EmbeddingAttribute(string)":
+                CheckAttributeIdentity(attribute, symbol, context);
+                return;
+
+            default:
+                return;
+        }
+    }
+
+    void CheckAttributeIdentity(AttributeSyntax attribute, IMethodSymbol symbol, SyntaxNodeAnalysisContext context)
+    {
+        var identityParameter = symbol.Parameters[0];
+        if (!attribute.TryGetArgumentValue(identityParameter, out var id)) return;
+        var identityText = id.GetText().ToString();
+
+        if (!Guid.TryParse(identityText.Trim('"'), out _))
+        {
+            var properties = ImmutableDictionary<string, string?>.Empty.Add("identityParameter", identityParameter.Name);
+            context.ReportDiagnostic(Diagnostic.Create(InvalidIdentityRule, attribute.GetLocation(), properties,
+                attribute.Name.ToString(), identityParameter.Name, identityText));
+        }
+    }
+}

--- a/Source/Analyzers/CodeFixes/AnnotationIdentityCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/AnnotationIdentityCodeFixProvider.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Dolittle.SDK.Analyzers.CodeFixes;
+
+public class AnnotationIdentityCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(DiagnosticIds.AnnotationInvalidIdentityRuleId);
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var document = context.Document;
+        var diagnostic = context.Diagnostics[0];
+        if (!diagnostic.Properties.TryGetValue("identityParameter", out var identityParameterName))
+        {
+            return;
+        }
+
+        switch (diagnostic.Id)
+        {
+            case DiagnosticIds.AnnotationInvalidIdentityRuleId:
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        "Generate identity", ct => GenerateIdentity(context, document, identityParameterName!, ct),
+                        nameof(AnnotationIdentityCodeFixProvider) + ".AddIdentity"),
+                    diagnostic);
+                break;
+            default:
+                break;
+        }
+    }
+
+
+    static async Task<Document> GenerateIdentity(CodeFixContext context, Document document, string identityParameterName,
+        CancellationToken cancellationToken)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(cancellationToken);
+        if (!TryGetTargetNode(context, root, out AttributeSyntax attribute)) return document; // Target not found
+        var updatedRoot = root.ReplaceNode(attribute, GenerateIdentity(attribute, identityParameterName));
+        return document.WithSyntaxRoot(updatedRoot);
+    }
+
+    static AttributeSyntax GenerateIdentity(AttributeSyntax existing, string identityParameterName)
+    {
+        var newIdentity = SyntaxFactory.ParseExpression("\"" + IdentityGenerator.Generate() + "\"");
+        if (existing.ArgumentList is not null && existing.TryGetArgumentValue(identityParameterName, 0, out var oldIdentity))
+        {
+            return existing.ReplaceNode(oldIdentity, newIdentity);
+        }
+
+        return existing.WithArgumentList(
+            SyntaxFactory.AttributeArgumentList(
+                SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.AttributeArgument(newIdentity))));
+    }
+
+    protected static bool TryGetTargetNode<TNode>(
+        CodeFixContext context,
+        SyntaxNode root,
+        out TNode node) where TNode : SyntaxNode
+    {
+#pragma warning disable CS8601
+        node = root
+            .FindNode(context.Span, false, getInnermostNodeForTie: true)?
+            .FirstAncestorOrSelf<TNode>(ascendOutOfTrivia: true);
+#pragma warning restore CS8601
+        return node is not null;
+    }
+
+
+    public override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+}

--- a/Source/Analyzers/CodeFixes/AnnotationIdentityCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/AnnotationIdentityCodeFixProvider.cs
@@ -16,13 +16,13 @@ public class AnnotationIdentityCodeFixProvider : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(DiagnosticIds.AnnotationInvalidIdentityRuleId);
 
-    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var document = context.Document;
         var diagnostic = context.Diagnostics[0];
         if (!diagnostic.Properties.TryGetValue("identityParameter", out var identityParameterName))
         {
-            return;
+            return Task.CompletedTask;
         }
 
         switch (diagnostic.Id)
@@ -34,9 +34,9 @@ public class AnnotationIdentityCodeFixProvider : CodeFixProvider
                         nameof(AnnotationIdentityCodeFixProvider) + ".AddIdentity"),
                     diagnostic);
                 break;
-            default:
-                break;
         }
+
+        return Task.CompletedTask;
     }
 
 

--- a/Source/Analyzers/DiagnosticCategories.cs
+++ b/Source/Analyzers/DiagnosticCategories.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Dolittle.SDK.Analyzers;
+
+public static class DiagnosticCategories
+{
+    public const string Sdk = "Dolittle.SDK";
+}

--- a/Source/Analyzers/DiagnosticIds.cs
+++ b/Source/Analyzers/DiagnosticIds.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Dolittle.SDK.Analyzers;
+
+public static class DiagnosticIds
+{
+    /// <summary>
+    /// Annotation missing the required ID.
+    /// </summary>
+    public const string AnnotationInvalidIdentityRuleId = "SDK0001";
+}

--- a/Source/Analyzers/IdentityGenerator.cs
+++ b/Source/Analyzers/IdentityGenerator.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dolittle.SDK.Analyzers;
+
+/// <summary>
+/// Hook to make code fixes testable
+/// </summary>
+static class IdentityGenerator
+{
+    internal static string? Override { get; set; }
+
+    public static string Generate() => Override ?? Guid.NewGuid().ToString();
+}

--- a/Source/Analyzers/InternalsVisibleTo.cs
+++ b/Source/Analyzers/InternalsVisibleTo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Dolittle.SDK.Analyzers.Tests")]

--- a/Source/Analyzers/Utils.cs
+++ b/Source/Analyzers/Utils.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Dolittle.SDK.Analyzers;
+
+static class Utils
+{
+    public static bool IsDolittleType(this ISymbol symbol)
+    {
+        var symbolNamespace = symbol.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        return symbolNamespace.StartsWith("global::Dolittle.SDK", StringComparison.Ordinal)
+               || symbolNamespace.StartsWith("Dolittle.SDK", StringComparison.Ordinal);
+    }
+
+    public static bool TryGetArgumentValue(this AttributeSyntax attribute, IParameterSymbol parameterSymbol, out ExpressionSyntax expressionSyntax) =>
+        attribute.TryGetArgumentValue(parameterSymbol.Name, parameterSymbol.Ordinal, out expressionSyntax);
+
+
+    public static bool TryGetArgumentValue(this AttributeSyntax attribute, string parameterName, int parameterOrdinal, out ExpressionSyntax expressionSyntax)
+    {
+        if (attribute.ArgumentList is null)
+        {
+            expressionSyntax = default!;
+            return false;
+        }
+
+        var ordinal = parameterOrdinal;
+        if (attribute.ArgumentList.Arguments.Count > ordinal)
+        {
+            var positionalArgument = attribute.ArgumentList.Arguments[ordinal];
+            if (positionalArgument.NameColon is null || positionalArgument.MatchesName(parameterName))
+            {
+                // parameter is positional or name matches
+                expressionSyntax = positionalArgument.Expression;
+                return true;
+            }
+        }
+
+        foreach (var argument in attribute.ArgumentList.Arguments)
+        {
+            if (argument.MatchesName(parameterName))
+            {
+                expressionSyntax = argument.Expression;
+                return true;
+            }
+        }
+
+        expressionSyntax = default!;
+        return false;
+    }
+
+    static bool MatchesName(this AttributeArgumentSyntax attributeArgument, string parameterName)
+    {
+        return attributeArgument.NameColon?.Name.Identifier.Text == parameterName;
+    }
+}

--- a/Tests/Aggregates/Aggregates.csproj
+++ b/Tests/Aggregates/Aggregates.csproj
@@ -2,6 +2,12 @@
 
     <Import Project="../../tests.props" />
 
+    <PropertyGroup>
+        <RootNamespace>Dolittle.SDK.Aggregates</RootNamespace>
+        <AssemblyName>Dolittle.SDK.Aggregates.Tests</AssemblyName>
+    </PropertyGroup>
+
+
     <ItemGroup>
       <ProjectReference Include="..\..\Source\Aggregates\Aggregates.csproj" />
     </ItemGroup>

--- a/Tests/Aggregates/ClusterIdentityMapperTests.cs
+++ b/Tests/Aggregates/ClusterIdentityMapperTests.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aggregates;
 using Dolittle.SDK.Aggregates.Actors;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Tenancy;
-using FluentAssertions;
 
-namespace Aggregates;
+namespace Dolittle.SDK.Aggregates;
 
 public class ClusterIdentityMapperTests
 {

--- a/Tests/Aggregates/Usings.cs
+++ b/Tests/Aggregates/Usings.cs
@@ -1,1 +1,2 @@
-﻿global using Xunit;
+﻿global using FluentAssertions;
+global using Xunit;

--- a/Tests/Analyzers/AnalyzerTest.cs
+++ b/Tests/Analyzers/AnalyzerTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Dolittle.SDK.Aggregates;
+using Dolittle.SDK.Embeddings;
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+using Dolittle.SDK.Projections;
+// using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+
+namespace Dolittle.SDK.Analyzers;
+
+public abstract class AnalyzerTest<TAnalyzer> where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    protected Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
+        {
+            TestState =
+            {
+                Sources = { source },
+                AdditionalReferences =
+                {
+                    Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(AggregateRootAttribute).Assembly.Location),
+                    Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(EventTypeAttribute).Assembly.Location),
+                    Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(ProjectionAttribute).Assembly.Location),
+                    Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(EventHandlerAttribute).Assembly.Location),
+                    Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(typeof(EmbeddingAttribute).Assembly.Location),
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+            }
+        };
+        test.TestState.ExpectedDiagnostics.AddRange(expected);
+
+        return test.RunAsync();
+    }
+
+    protected DiagnosticResult Diagnostic()
+    {
+        return AnalyzerVerifier<TAnalyzer>.Diagnostic();
+    }
+
+    protected DiagnosticResult Diagnostic(Microsoft.CodeAnalysis.DiagnosticDescriptor descriptor)
+    {
+        return AnalyzerVerifier<TAnalyzer>.Diagnostic(descriptor);
+    }
+}

--- a/Tests/Analyzers/Analyzers.csproj
+++ b/Tests/Analyzers/Analyzers.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <RootNamespace>Dolittle.SDK.Analyzers</RootNamespace>
+        <AssemblyName>Dolittle.SDK.Analyzers.Tests</AssemblyName>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Source\Aggregates\Aggregates.csproj" />
+        <ProjectReference Include="..\..\Source\Analyzers\Analyzers.csproj" />
+        <ProjectReference Include="..\..\Source\Embeddings\Embeddings.csproj" />
+        <ProjectReference Include="..\..\Source\Events.Handling\Events.Handling.csproj" />
+        <ProjectReference Include="..\..\Source\Projections\Projections.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Tests/Analyzers/CodeFixProviderTests.cs
+++ b/Tests/Analyzers/CodeFixProviderTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.SDK.Aggregates;
+using Dolittle.SDK.Embeddings;
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+using Dolittle.SDK.Projections;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Dolittle.SDK.Analyzers;
+
+public abstract class CodeFixProviderTests<TAnalyzer, TCodeFix> : AnalyzerTest<TAnalyzer>
+    where TCodeFix : CodeFixProvider, new()
+    where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    protected Task VerifyCodeFixAsync(string source, string expectedResult, DiagnosticResult diagnosticResult)
+    {
+        return new CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+        {
+            TestCode = source,
+            TestState =
+            {
+                AdditionalReferences =
+                {
+                    MetadataReference.CreateFromFile(typeof(AggregateRootAttribute).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(EventTypeAttribute).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(ProjectionAttribute).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(EventHandlerAttribute).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(EmbeddingAttribute).Assembly.Location),
+                },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            },
+            ExpectedDiagnostics =
+            {
+                diagnosticResult
+            },
+            FixedCode = expectedResult,
+        }.RunAsync(CancellationToken.None);
+    }
+}

--- a/Tests/Analyzers/CodeFixes/AnnotationIdentityCodeFixTests.cs
+++ b/Tests/Analyzers/CodeFixes/AnnotationIdentityCodeFixTests.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Dolittle.SDK.Analyzers.CodeFixes;
+
+public class AnnotationIdentityCodeFixTests : CodeFixProviderTests<AnnotationIdentityAnalyzer, AnnotationIdentityCodeFixProvider>
+{
+    [Fact]
+    public async Task FixAnnotationWithInvalidIdentity()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+
+[EventType("""")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+
+        var expected = @"
+using Dolittle.SDK.Events;
+
+[EventType(""61359cf4-3ae7-4a26-8a81-6816d3877f81"")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+        IdentityGenerator.Override = "61359cf4-3ae7-4a26-8a81-6816d3877f81";
+        var diagnosticResult = Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+            .WithSpan(4, 2, 4, 15)
+            .WithArguments("EventType", "eventTypeId", @"""""");
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+
+    [Fact]
+    public async Task FixesAnnotationWithInvalidIdentityWithNamedArguments()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+
+[EventType(eventTypeId: """")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+
+        var expected = @"
+using Dolittle.SDK.Events;
+
+[EventType(eventTypeId: ""61359cf4-3ae7-4a26-8a81-6816d3877f81"")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+        IdentityGenerator.Override = "61359cf4-3ae7-4a26-8a81-6816d3877f81";
+
+        var diagnosticResult = Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+            .WithSpan(4, 2, 4, 28)
+            .WithArguments("EventType", "eventTypeId", @"""""");
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+    
+    [Fact]
+    public async Task FixesAnnotationWithInvalidIdentityWithNamedArgumentsInNonDefaultPosition()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+
+[EventType(alias: ""Foo"", eventTypeId: """")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+
+        var expected = @"
+using Dolittle.SDK.Events;
+
+[EventType(alias: ""Foo"", eventTypeId: ""61359cf4-3ae7-4a26-8a81-6816d3877f81"")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+        IdentityGenerator.Override = "61359cf4-3ae7-4a26-8a81-6816d3877f81";
+
+        var diagnosticResult = Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+            .WithSpan(4, 2, 4, 42)
+            .WithArguments("EventType", "eventTypeId", @"""""");
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+    
+    [Fact]
+    public async Task FixesEventHandlers()
+    {
+        var test = @"
+using Dolittle.SDK.Events.Handling;
+
+[EventHandler(alias: ""Foo"", eventHandlerId: ""invalid-id"")]
+class SomeHandler
+{
+}";
+
+        var expected = @"
+using Dolittle.SDK.Events.Handling;
+
+[EventHandler(alias: ""Foo"", eventHandlerId: ""61359cf4-3ae7-4a26-8a81-6816d3877f81"")]
+class SomeHandler
+{
+}";
+        IdentityGenerator.Override = "61359cf4-3ae7-4a26-8a81-6816d3877f81";
+
+        var diagnosticResult = Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+            .WithSpan(4, 2, 4, 58)
+            .WithArguments("EventHandler", "eventHandlerId", @"""invalid-id""");
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+    
+    [Fact]
+    public async Task FixesProjections()
+    {
+        var test = @"
+using Dolittle.SDK.Projections;
+
+[Projection(alias: ""Foo"", projectionId: ""invalid-id"")]
+class SomeProjection
+{
+}";
+
+        var expected = @"
+using Dolittle.SDK.Projections;
+
+[Projection(alias: ""Foo"", projectionId: ""61359cf4-3ae7-4a26-8a81-6816d3877f81"")]
+class SomeProjection
+{
+}";
+        IdentityGenerator.Override = "61359cf4-3ae7-4a26-8a81-6816d3877f81";
+
+        var diagnosticResult = Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+            .WithSpan(4, 2, 4, 54)
+            .WithArguments("Projection", "projectionId", @"""invalid-id""");
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+    
+    [Fact]
+    public async Task FixesAggregates()
+    {
+        var test = @"
+using Dolittle.SDK.Aggregates;
+
+[AggregateRoot(alias: ""Foo"", id: ""invalid-id"")]
+class SomeAggregate
+{
+}";
+
+        var expected = @"
+using Dolittle.SDK.Aggregates;
+
+[AggregateRoot(alias: ""Foo"", id: ""61359cf4-3ae7-4a26-8a81-6816d3877f81"")]
+class SomeAggregate
+{
+}";
+        IdentityGenerator.Override = "61359cf4-3ae7-4a26-8a81-6816d3877f81";
+
+        var diagnosticResult = Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+            .WithSpan(4, 2, 4, 47)
+            .WithArguments("AggregateRoot", "id", @"""invalid-id""");
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+    
+    [Fact]
+    public async Task FixesEmbeddings()
+    {
+        var test = @"
+using Dolittle.SDK.Embeddings;
+
+[Embedding(embeddingId: ""invalid-id"")]
+class SomeAggregate
+{
+}";
+
+        var expected = @"
+using Dolittle.SDK.Embeddings;
+
+[Embedding(embeddingId: ""61359cf4-3ae7-4a26-8a81-6816d3877f81"")]
+class SomeAggregate
+{
+}";
+        IdentityGenerator.Override = "61359cf4-3ae7-4a26-8a81-6816d3877f81";
+
+        var diagnosticResult = Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+            .WithSpan(4, 2, 4, 38)
+            .WithArguments("Embedding", "embeddingId", @"""invalid-id""");
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+
+}
+

--- a/Tests/Analyzers/Diagnostics/AnnotationAnalyzerUnitTests.cs
+++ b/Tests/Analyzers/Diagnostics/AnnotationAnalyzerUnitTests.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using System;
+using System.Threading.Tasks;
+
+namespace Dolittle.SDK.Analyzers;
+
+public class AnnotationAnalyzerUnitTests : AnalyzerTest<AnnotationIdentityAnalyzer>
+{
+    [Fact]
+    public async Task ShouldDetectEventTypeWithUsing()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+
+[EventType("""")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+                .WithSpan(4, 2, 4, 15)
+                .WithArguments("EventType", "eventTypeId", "\"\"")
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ShouldDetectEventTypeWhenQualified()
+    {
+        var test = @"
+[Dolittle.SDK.Events.EventType("""")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+                .WithSpan(2, 2, 2, 35)
+                .WithArguments("Dolittle.SDK.Events.EventType", "eventTypeId", "\"\""),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ShouldNotDetectEventTypeWhenItHasValidId()
+    {
+        var test = @"
+[Dolittle.SDK.Events.EventType(""e8879da9-fd28-4c78-b9cc-1381a09c3e79"")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+
+        await VerifyAnalyzerAsync(test, Array.Empty<DiagnosticResult>());
+    }
+
+    [Fact]
+    public async Task ShouldNotDetectEventTypeWhenItHasValidIdAndNamedArguments()
+    {
+        var test = @"
+[Dolittle.SDK.Events.EventType(alias: ""Bob"", eventTypeId: ""c6f87322-be67-4aaf-a9f4-fdc24ac4f0fb"")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+
+        await VerifyAnalyzerAsync(test, Array.Empty<DiagnosticResult>());
+    }
+
+    [Fact]
+    public async Task ShouldDetectEventTypeWithInvalidNamedArguments()
+    {
+        var test = @"
+[Dolittle.SDK.Events.EventType(alias: ""Bob"", eventTypeId: ""c6f87322-be67-4aaf"")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(AnnotationIdentityAnalyzer.InvalidIdentityRule)
+                .WithSpan(2, 2, 2, 80)
+                .WithArguments("Dolittle.SDK.Events.EventType", "eventTypeId", "\"c6f87322-be67-4aaf\"")
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ShouldIgnoreIrrelevantAnnotations()
+    {
+        var test = @"
+[System.Serializable]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+
+        await VerifyAnalyzerAsync(test, Array.Empty<DiagnosticResult>());
+    }
+}

--- a/Tests/Analyzers/Usings.cs
+++ b/Tests/Analyzers/Usings.cs
@@ -1,0 +1,2 @@
+global using Microsoft.CodeAnalysis.Testing;
+global using Xunit;

--- a/base.props
+++ b/base.props
@@ -1,0 +1,32 @@
+<Project>
+    <Import Project="versions.props"/>
+    
+    <PropertyGroup>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <LangVersion>latest</LangVersion>
+        <RepositoryUrl>https://github.com/dolittle/DotNET.SDK</RepositoryUrl>
+        <PackageProjectUrl>https://dolittle.io</PackageProjectUrl>
+        <PackageReleaseNotes>https://github.com/dolittle/DotNET.SDK/blob/master/CHANGELOG.md</PackageReleaseNotes>
+        <DocumentationFile>bin/$(Configuration)/$(TargetFramework)/$(AssemblyName).xml</DocumentationFile>
+        <NoWarn>$(NoWarn);SYSLIB1002;SYSLIB1006;SYSLIB1007</NoWarn>
+        <Nullable>enable</Nullable>
+
+        <Description>Dolittle is a decentralized, distributed, event-driven microservice platform built to harness the power of events.</Description>
+        <PackageTags>Dolittle;Events;Event Sourcing;Domain Driven Design;Event Driven Architecture;Line of Business;ES;DDD;EDA;LOB</PackageTags>
+        <PackageIcon>logo.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Copyright>Copyright Dolittle</Copyright>
+        <Authors>all contributors</Authors>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)/Assets/logo.png" Pack="true" PackagePath="/logo.png" />
+        <None Include="$(MSBuildThisFileDirectory)/Assets/PACKAGE-README.md" Pack="true" PackagePath="/README.md" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <Compile Include="$(MSBuildThisFileDirectory)/LegacySupport/IsExternalInit.cs" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.0' OR '$(TargetFramework)' == 'netcoreapp3.1'" />
+    </ItemGroup>
+</Project>

--- a/netstandard.props
+++ b/netstandard.props
@@ -2,6 +2,6 @@
     <Import Project="base.props"/>
     
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 </Project>

--- a/versions.props
+++ b/versions.props
@@ -13,6 +13,7 @@
         <ProtobufVersion>3.18.1</ProtobufVersion>
         <GrpcVersion>2.43.0</GrpcVersion>
         <MongoDBDriverVersion>2.13.2</MongoDBDriverVersion>
+        <OpenTelemetryVersion>1.3.1</OpenTelemetryVersion>
         <MongoDBOpenTelemetryVersion>1.0.0</MongoDBOpenTelemetryVersion>
         <NewtonsoftVersion>12.0.3</NewtonsoftVersion>
         <SystemImmutableVersion>1.7.1</SystemImmutableVersion>


### PR DESCRIPTION
## Summary

Adds Roslyn analyzers for validating Guid id's in attributes and generating new ID's.

Restructures internals to put marker attributes / id's in separate Core project to allow the analyzers to target netstandard 2.0.