### PR TITLE
Fix a  bug in DolittleClient causing it to always crash

### DIFF
--- a/Source/SDK/DolittleClient.cs
+++ b/Source/SDK/DolittleClient.cs
@@ -337,7 +337,10 @@ public class DolittleClient : IDisposable, IDolittleClient
             _callContextResolver,
             _unregisteredEventTypes,
             loggerFactory);
-        Aggregates = new AggregatesBuilder(Services.ForTenant);
+        // Important to not send in the method group because it will crash because it calls get on the Services-property before it is ready.
+#pragma warning disable IDE0200
+        Aggregates = new AggregatesBuilder(tenant => Services.ForTenant(tenant));
+#pragma warning restore IDE0200
         EventHorizons = new EventHorizons(
             methodCaller,
             executionContext,


### PR DESCRIPTION
## Summary

Fixes a critical bug in the DolittleClient preventing all clients to crash.

### Fixed

- Bug in starting up DolittleClient
