### PR TITLE
Trigger release

### DIFF
--- a/.github/workflows/dotnet-library.yml
+++ b/.github/workflows/dotnet-library.yml
@@ -1,7 +1,7 @@
 name: .NET Library CI/CD
 
 env:
-  PRERELEASE_BRANCHES: elrond # Comma separated list of prerelease branch names. 'alpha,rc, ...'
+  PRERELEASE_BRANCHES: elrond,test # Comma separated list of prerelease branch names. 'alpha,rc, ...'
   NUGET_OUTPUT: Artifacts/NuGet
   COVERAGE_FOLDER: Coverage
 


### PR DESCRIPTION
## Summary

(See previous PR for changes https://github.com/dolittle/DotNET.SDK/pull/193)
Make it possible to automatically discover and register tenant-scoped services. This is not meant to be a replacement for the 
`WithTenantServices` method on the Dolittle configuration callback as that will still need to be used for services that requires more complicated registration, but the new attribute-based registration should suffice for most situations.
### Added

- `PerTenant` attribute that can be used to mark classes as PerTenant-scoped services. The `PerTenant` attribute has a couple of options in terms of `ServiceLifetime` (Transient by default) and whether the service should be registered as itself (off by default)