### PR TITLE
Reverse Call Pinging is now optional

### DIFF
--- a/Source/SDK/Builders/DolittleClientConfiguration.cs
+++ b/Source/SDK/Builders/DolittleClientConfiguration.cs
@@ -36,7 +36,7 @@ public class DolittleClientConfiguration : IConfigurationBuilder
     /// <summary>
     /// Gets the ping-interval <see cref="TimeSpan"/>.
     /// </summary>
-    public TimeSpan PingInterval { get; private set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan PingInterval { get; private set; } = TimeSpan.MaxValue;
 
     /// <summary>
     /// How long should the aggregates be kept in memory when not in use.


### PR DESCRIPTION
## Summary

Makes it possible for the Runtime to not have to send any pings to the SDK for reverse call streams by having that be the default unless PingInterval is explicitly configured. This is done in a way that should be compatible with older Runtimes, but the newest Runtime versions should have a slightly more optimized path for these non-pinging reverse call connections.

### Changed

- When PingInterval is not explicitly configured the reverse calls will not do any ping-ponging anymore