### PR TITLE
Allow users to configure MongoDB client settings

### DIFF
--- a/Source/Resources/Internal/ResourcesFetcher.cs
+++ b/Source/Resources/Internal/ResourcesFetcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +11,7 @@ using Dolittle.SDK.Resources.MongoDB.Internal;
 using Dolittle.SDK.Services;
 using Dolittle.SDK.Tenancy;
 using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
 using ExecutionContext = Dolittle.SDK.Execution.ExecutionContext;
 
 namespace Dolittle.SDK.Resources.Internal;
@@ -20,16 +22,17 @@ namespace Dolittle.SDK.Resources.Internal;
 public class ResourcesFetcher : IFetchResources
 {
     readonly MongoDBResourceCreator _mongoDB;
-    
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ResourcesFetcher"/> class.
     /// </summary>
     /// <param name="methodCaller">The method caller to make requests to the Runtime with.</param>
     /// <param name="executionContext">The base execution context for the client.</param>
+    /// <param name="configureClientSettings"></param>
     /// <param name="loggerFactory">The logger factory to use to create loggers.</param>
-    public ResourcesFetcher(IPerformMethodCalls methodCaller, ExecutionContext executionContext, ILoggerFactory loggerFactory)
+    public ResourcesFetcher(IPerformMethodCalls methodCaller, ExecutionContext executionContext, Action<MongoClientSettings> configureClientSettings, ILoggerFactory loggerFactory)
     {
-        _mongoDB = new MongoDBResourceCreator(methodCaller, executionContext, loggerFactory);
+        _mongoDB = new MongoDBResourceCreator(methodCaller, executionContext, configureClientSettings, loggerFactory);
     }
 
     /// <inheritdoc />

--- a/Source/Resources/MongoDB/Internal/MongoDBResource.cs
+++ b/Source/Resources/MongoDB/Internal/MongoDBResource.cs
@@ -4,7 +4,6 @@
 using System;
 using Dolittle.Runtime.Resources.Contracts;
 using MongoDB.Driver;
-using MongoDB.Driver.Core.Extensions.DiagnosticSources;
 
 namespace Dolittle.SDK.Resources.MongoDB.Internal;
 
@@ -19,12 +18,13 @@ public class MongoDBResource : IMongoDBResource
     /// <summary>
     /// Initializes a new instance of the <see cref="MongoDBResource"/> class.
     /// </summary>
-    /// <param name="runtimeMongoDBResponse">The MongoDB resource response from the Runtime.</param>
-    public MongoDBResource(GetMongoDBResponse runtimeMongoDBResponse)
+    /// <param name="runtimeMongoDbResponse">The MongoDB resource response from the Runtime.</param>
+    /// <param name="clientSettingsCallback"></param>
+    public MongoDBResource(GetMongoDBResponse runtimeMongoDbResponse, Action<MongoClientSettings>? clientSettingsCallback)
     {
-        _mongoUrl = MongoUrl.Create(runtimeMongoDBResponse.ConnectionString);
+        _mongoUrl = MongoUrl.Create(runtimeMongoDbResponse.ConnectionString);
         var clientSettings = MongoClientSettings.FromUrl(_mongoUrl);
-        clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber());
+        clientSettingsCallback?.Invoke(clientSettings);
         _mongoClient = new MongoClient(clientSettings.Freeze());
     }
 

--- a/Source/Resources/MongoDB/Internal/MongoDBResourceCreator.cs
+++ b/Source/Resources/MongoDB/Internal/MongoDBResourceCreator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Dolittle.Protobuf.Contracts;
 using Dolittle.Runtime.Resources.Contracts;
 using Dolittle.SDK.Execution;
@@ -8,6 +9,7 @@ using Dolittle.SDK.Resources.Internal;
 using Dolittle.SDK.Services;
 using Dolittle.Services.Contracts;
 using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
 
 namespace Dolittle.SDK.Resources.MongoDB.Internal;
 
@@ -16,15 +18,20 @@ namespace Dolittle.SDK.Resources.MongoDB.Internal;
 /// </summary>
 public class MongoDBResourceCreator : ResourceCreator<MongoDBResource, GetRequest, GetMongoDBResponse>
 {
+    readonly Action<MongoClientSettings> _configureClientSettings;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MongoDBResourceCreator"/> class.
     /// </summary>
     /// <param name="methodCaller">The method caller to make requests to the Runtime with.</param>
     /// <param name="executionContext">The base execution context for the client.</param>
+    /// <param name="configureClientSettings">MongoDB client settings configuration</param>
     /// <param name="loggerFactory">The logger factory to use to create loggers.</param>
-    public MongoDBResourceCreator(IPerformMethodCalls methodCaller, ExecutionContext executionContext, ILoggerFactory loggerFactory)
+    public MongoDBResourceCreator(IPerformMethodCalls methodCaller, ExecutionContext executionContext, Action<MongoClientSettings> configureClientSettings,
+        ILoggerFactory loggerFactory)
         : base("MongoDB", new ResourcesGetMongoDBMethod(), methodCaller, executionContext, loggerFactory)
     {
+        _configureClientSettings = configureClientSettings;
     }
 
     /// <inheritdoc />
@@ -40,5 +47,5 @@ public class MongoDBResourceCreator : ResourceCreator<MongoDBResource, GetReques
 
     /// <inheritdoc />
     protected override MongoDBResource CreateResourceFrom(GetMongoDBResponse response)
-        => new(response);
+        => new(response,_configureClientSettings);
 }

--- a/Source/SDK/Builders/DolittleClientConfiguration.cs
+++ b/Source/SDK/Builders/DolittleClientConfiguration.cs
@@ -8,6 +8,7 @@ using Dolittle.SDK.Diagnostics.OpenTelemetry;
 using Dolittle.SDK.Microservices;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
+using MongoDB.Driver.Core.Extensions.DiagnosticSources;
 using Newtonsoft.Json;
 using Version = Dolittle.SDK.Microservices.Version;
 
@@ -72,11 +73,17 @@ public class DolittleClientConfiguration : IConfigurationBuilder
     /// Gets the <see cref="CreateTenantServiceProvider"/> factory.
     /// </summary>
     public CreateTenantServiceProvider? TenantServiceProviderFactory { get; private set; }
-    
+
     /// <summary>
     /// Gets the callback for configuring the <see cref="MongoDatabaseSettings"/>.
     /// </summary>
     public Action<MongoDatabaseSettings>? ConfigureMongoDatabaseSettings { get; private set; }
+
+    /// <summary>
+    /// Gets the callback for configuring the <see cref="MongoClientSettings"/>.
+    /// </summary>
+    public Action<MongoClientSettings> ConfigureMongoClientSettings { get; private set; } = settings =>
+        settings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber());
 
     /// <summary>
     /// Configures the <see cref="DolittleClientConfiguration"/> with the configuration values from <see cref="Configurations.Dolittle"/>.
@@ -215,6 +222,13 @@ public class DolittleClientConfiguration : IConfigurationBuilder
     public IConfigurationBuilder WithMongoDatabaseSettings(Action<MongoDatabaseSettings> configureMongoDatabase)
     {
         ConfigureMongoDatabaseSettings = configureMongoDatabase;
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IConfigurationBuilder WithMongoClientSettings(Action<MongoClientSettings> configureMongoClient)
+    {
+        ConfigureMongoClientSettings = configureMongoClient;
         return this;
     }
 }

--- a/Source/SDK/Builders/IConfigurationBuilder.cs
+++ b/Source/SDK/Builders/IConfigurationBuilder.cs
@@ -95,4 +95,11 @@ public interface IConfigurationBuilder
     /// <param name="configureMongoDatabase">The callback for configuring <see cref="MongoDatabaseSettings"/>.</param>
     /// <returns>The builder for continuation.</returns>
     IConfigurationBuilder WithMongoDatabaseSettings(Action<MongoDatabaseSettings> configureMongoDatabase);
+    
+    /// <summary>
+    /// Configures the <see cref="MongoClient"/> used. Please note that setting this will override the default configured tracing of MongoDB.
+    /// </summary>
+    /// <param name="configureMongoClient">The callback for configuring <see cref="MongoClientSettings"/>.</param>
+    /// <returns>The builder for continuation.</returns>
+    IConfigurationBuilder WithMongoClientSettings(Action<MongoClientSettings> configureMongoClient);
 }

--- a/Source/SDK/DolittleClient.cs
+++ b/Source/SDK/DolittleClient.cs
@@ -250,7 +250,7 @@ public class DolittleClient : IDisposable, IDolittleClient
                 await ConnectToRuntime(methodCaller, configuration, loggerFactory, cancellationToken).ConfigureAwait(false);
             Tenants = tenants;
 
-            await CreateDependencies(methodCaller, configuration.EventSerializerProvider, loggerFactory, executionContext, tenants).ConfigureAwait(false);
+            await CreateDependencies(methodCaller, configuration, loggerFactory, executionContext, tenants).ConfigureAwait(false);
             ConfigureContainer(configuration);
             await RegisterAllUnregistered(methodCaller, configuration.PingInterval, executionContext, loggerFactory).ConfigureAwait(false);
 
@@ -317,13 +317,13 @@ public class DolittleClient : IDisposable, IDolittleClient
 
     async Task CreateDependencies(
         IPerformMethodCalls methodCaller,
-        Func<JsonSerializerSettings> eventSerializerProvider,
+        DolittleClientConfiguration config,
         ILoggerFactory loggerFactory,
         ExecutionContext executionContext,
         IEnumerable<Tenant> tenants)
     {
         _clientCancellationTokenSource = new CancellationTokenSource();
-        var serializer = new EventContentSerializer(_unregisteredEventTypes, eventSerializerProvider);
+        var serializer = new EventContentSerializer(_unregisteredEventTypes, config.EventSerializerProvider);
         _eventsToProtobufConverter = new EventToProtobufConverter(serializer);
         _eventToSDKConverter = new EventToSDKConverter(serializer);
 
@@ -363,6 +363,7 @@ public class DolittleClient : IDisposable, IDolittleClient
         Resources = await new ResourcesFetcher(
             methodCaller,
             executionContext,
+            config.ConfigureMongoClientSettings,
             loggerFactory
         ).FetchResourcesFor(tenants, _clientCancellationTokenSource.Token).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary

Allows users to override MongoDB client settings. Moves MongoDB trace config into the main client config, and allows it to be overwritten.

### Added

- `IConfigurationBuilder.WithMongoClientSettings`
