### PR TITLE
Aggregate request deduplication

### DIFF
--- a/Source/Aggregates/Actors/AggregateClusterKindFactory.cs
+++ b/Source/Aggregates/Actors/AggregateClusterKindFactory.cs
@@ -30,6 +30,6 @@ static class AggregateClusterKindFactory<TAggregate> where TAggregate : Aggregat
         var idleUnloadTimeout = serviceProvider.GetRequiredService<AggregateUnloadTimeout>()();
 
         return new ClusterKind(aggregateRootType.Id.Value.ToString(),
-            Props.FromProducer(() => new AggregateActor<TAggregate>(providerForTenant, logger, idleUnloadTimeout)));
+            Props.FromProducer(() => new AggregateActor<TAggregate>(providerForTenant, logger, idleUnloadTimeout)).WithClusterRequestDeduplication());
     }
 }

--- a/Source/Testing/Aggregates/AggregateRootAssertion.cs
+++ b/Source/Testing/Aggregates/AggregateRootAssertion.cs
@@ -45,6 +45,20 @@ public class AggregateRootAssertion
     public EventSequenceAssertion<T> ShouldHaveEvent<T>()
         where T : class
         => ShouldHaveEvent<T>(false);
+    
+    /// <summary>
+    /// Asserts that there was produced exactly one event, and of the specified type. Returns the Event value assertion for the event.
+    /// </summary>
+    /// <typeparam name="T"><see cref="Type" /> of the event that you wish to assert against.</typeparam>
+    /// <returns>An <see cref="EventSequenceAssertion{T}" /> scoped to your event type.</returns>
+    public EventValueAssertion<T> ShouldHaveSingleEvent<T>()
+        where T : class
+    {
+        // Ensure that there is only one event
+        ShouldHaveNumberOfEvents(1);
+        // And that it is the correct type. Return the value assertion for the event
+        return ShouldHaveEvent<T>(false).Single();
+    }
 
     /// <summary>
     /// Starts the Fluent Interface by establishing an Event sequence to assert against.

--- a/Source/Testing/Aggregates/AggregateRootTests.cs
+++ b/Source/Testing/Aggregates/AggregateRootTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+
+
+using System;
+using Dolittle.SDK.Aggregates;
+using Dolittle.SDK.Events;
+
+namespace Dolittle.SDK.Testing.Aggregates;
+
+public abstract class AggregateRootTests<T> where T : AggregateRoot
+{
+    readonly EventSourceId _eventSourceId;
+    readonly AggregateOfMock<T> _aggregateOf;
+    public AggregateRootAssertion AssertThat { get; private set; } = null!;
+
+    protected IAggregateRootOperations<T> Aggregate { get; }
+
+    protected AggregateRootTests(Func<EventSourceId, T> getAggregate, EventSourceId eventSourceId)
+    {
+        _eventSourceId = eventSourceId;
+        _aggregateOf = new AggregateOfMock<T>(getAggregate);
+        Aggregate = _aggregateOf.Get(eventSourceId);
+    }
+
+    protected void WithAggregateInState(Action<T> action)
+    {
+        Aggregate.Perform(action).GetAwaiter().GetResult();
+    }
+
+    protected AggregateRootAssertion WhenPerforming(Action<T> action)
+    {
+        // last perform is the one that is asserted on
+        Aggregate.Perform(action).GetAwaiter().GetResult();
+        AssertThat = _aggregateOf.AfterLastOperationOn(_eventSourceId);
+        return AssertThat;
+    }
+}

--- a/Source/Testing/Aggregates/Events/EventSequenceAssertion.cs
+++ b/Source/Testing/Aggregates/Events/EventSequenceAssertion.cs
@@ -44,6 +44,22 @@ public class EventSequenceAssertion<T>
     /// Asserts that an event of the specified type is present anywhere in the sequence, allowing further assertions against the first instance.
     /// </summary>
     /// <returns>An EventValueAssertion{T} to allow assertions against the event instance.</returns>
+#pragma warning disable CA1720
+    public EventValueAssertion<T> Single()
+#pragma warning restore CA1720
+    {
+        var numConformingEvents = _conformingEvents.Count;
+        if (numConformingEvents != 1)
+        {
+            _throwError($"there are {numConformingEvents} conforming events, not 1");
+        }
+        return new EventValueAssertion<T>(_conformingEvents.First());
+    }
+
+    /// <summary>
+    /// Asserts that an event of the specified type is present anywhere in the sequence, allowing further assertions against the first instance.
+    /// </summary>
+    /// <returns>An EventValueAssertion{T} to allow assertions against the event instance.</returns>
     public EventValueAssertion<T> First()
         => new(_conformingEvents.First());
 


### PR DESCRIPTION
## Summary
Removed retries against aggregate actors. Added new test classes for Aggregates.

### Added
- Additional helpers / assertions for testing aggregate roots

### Fixed
- Removed potential retries on Aggregate.Perform, which could occur when response times are greater than the set retry timeout.