### PR TITLE
Test library improvements

### DIFF
--- a/Source/Testing/Aggregates/Events/EventValueAssertion.cs
+++ b/Source/Testing/Aggregates/Events/EventValueAssertion.cs
@@ -12,7 +12,10 @@ namespace Dolittle.SDK.Testing.Aggregates.Events;
 public class EventValueAssertion<T>
     where T : class
 {
-    readonly T _event;
+    /// <summary>
+    /// Gets the event that is being asserted against.
+    /// </summary>
+    public T Event { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EventValueAssertion{T}"/> class with the event to assert against.
@@ -20,7 +23,7 @@ public class EventValueAssertion<T>
     /// <param name="evt">The event you wish to assert against.</param>
     public EventValueAssertion(T evt)
     {
-        _event = evt;
+        Event = evt;
     }
 
     /// <summary>
@@ -31,7 +34,7 @@ public class EventValueAssertion<T>
     {
         foreach (var assert in assertions)
         {
-            assert(_event);
+            assert(Event);
         }
     }
 }

--- a/Specifications/Testing/Aggregates/AggregateRootWithDefaultConstructor.cs
+++ b/Specifications/Testing/Aggregates/AggregateRootWithDefaultConstructor.cs
@@ -10,8 +10,9 @@ public class AggregateRootWithDefaultConstructor : AggregateRoot
 
     public void EventCausingNoStateChange()
     {
-        Apply(new EventCausingNoStateChange());
+        Apply(new EventCausingNoStateChange(EventSourceId.Value));
     }
+    
     public void Fail()
     {
         throw TheFailure;

--- a/Specifications/Testing/Aggregates/AggregateRootWithDependencies.cs
+++ b/Specifications/Testing/Aggregates/AggregateRootWithDependencies.cs
@@ -19,7 +19,7 @@ public class AggregateRootWithDependencies : AggregateRoot
     
     public void EventCausingNoStateChange()
     {
-        Apply(new EventCausingNoStateChange());
+        Apply(new EventCausingNoStateChange(EventSourceId.Value));
     }
     public void Fail()
     {

--- a/Specifications/Testing/Aggregates/EventCausingNoStateChange.cs
+++ b/Specifications/Testing/Aggregates/EventCausingNoStateChange.cs
@@ -3,4 +3,4 @@ using Dolittle.SDK.Events;
 namespace Dolittle.SDK.Testing.Aggregates;
 
 [EventType("7d623870-54e5-4a73-a02d-1bac4f906e5a")]
-public record EventCausingNoStateChange;
+public record EventCausingNoStateChange(string EventSourceId);

--- a/Specifications/Testing/Aggregates/StatefulAggregateRoot.cs
+++ b/Specifications/Testing/Aggregates/StatefulAggregateRoot.cs
@@ -18,7 +18,7 @@ public class StatefulAggregateRoot : AggregateRoot
     
     public void EventCausingNoStateChange()
     {
-        Apply(new EventCausingNoStateChange());
+        Apply(new EventCausingNoStateChange(EventSourceId.Value));
     }
     public void EventCausingStateChange(int theNewState)
     {

--- a/Specifications/Testing/Aggregates/StatelessAggregateRoot.cs
+++ b/Specifications/Testing/Aggregates/StatelessAggregateRoot.cs
@@ -18,7 +18,7 @@ public class StatelessAggregateRoot : AggregateRoot
 
     public void EventCausingNoStateChange()
     {
-        Apply(new EventCausingNoStateChange());
+        Apply(new EventCausingNoStateChange(EventSourceId.Value));
     }
     public void Fail()
     {

--- a/Specifications/Testing/Aggregates/for_AggregateMock/given/an_aggregate_with_default_constructor.cs
+++ b/Specifications/Testing/Aggregates/for_AggregateMock/given/an_aggregate_with_default_constructor.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.SDK.Testing.Aggregates.for_AggregateMock.given;
+
+class an_aggregate_with_default_constructor
+{
+    protected static AggregateOfMock<AggregateRootWithDefaultConstructor> aggregate_of;
+    
+    Establish context = () =>
+    {
+        aggregate_of = AggregateOfMock<AggregateRootWithDefaultConstructor>.Create();
+    };
+}

--- a/Specifications/Testing/Aggregates/for_AggregateMock/when_performing_operations/on_default_constructor_aggregate/and_operation_does_not_fail.cs
+++ b/Specifications/Testing/Aggregates/for_AggregateMock/when_performing_operations/on_default_constructor_aggregate/and_operation_does_not_fail.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.SDK.Events;
+using Machine.Specifications;
+
+namespace Dolittle.SDK.Testing.Aggregates.for_AggregateMock.when_performing_operations.on_default_constructor_aggregate;
+
+class and_operation_does_not_fail : given.an_aggregate_with_default_constructor
+{
+    static EventSourceId event_source;
+    static int new_state;
+
+    Establish context = () =>
+    {
+        event_source = "event source";
+        new_state = 3;
+    };
+    
+    Because of = () => aggregate_of.Get(event_source).Perform(_ => _.EventCausingNoStateChange()).GetAwaiter().GetResult();
+
+    It should_after_last_operation_have_the_correct_event = () => aggregate_of.AfterLastOperationOn(event_source).ShouldHaveEvent<EventCausingNoStateChange>()
+        .CountOf(1)
+        .AtEnd()
+        .Where(_ => _.EventSourceId.ShouldEqual(event_source.Value));
+}

--- a/Specifications/Testing/Aggregates/for_AggregatesMock/given/spec_for.cs
+++ b/Specifications/Testing/Aggregates/for_AggregatesMock/given/spec_for.cs
@@ -25,6 +25,8 @@ class spec_for<TAggregate>
         aggregate_of = get_aggregate_of();
         aggregate_of_mock = aggregate_of as AggregateOfMock<TAggregate>;
     }
+    
+    
 
     protected static IAggregateOf<TAggregate> get_aggregate_of()
     {


### PR DESCRIPTION
## Summary
Minor Dolittle.SDK.Testing improvements

### Added
- Added ability to access the events being asserted on in `EventValueAssertion<T>`.

### Fixed
- Fixed an issue with `EventSourceId` not being set during testing when using aggregate roots with default constructor.

