### PR TITLE
Trace improvements

### DIFF
--- a/Source/Aggregates/AggregateRootOperations.cs
+++ b/Source/Aggregates/AggregateRootOperations.cs
@@ -68,7 +68,11 @@ public class AggregateRootOperations<TAggregate> : IAggregateRootOperations<TAgg
         catch (AggregateRootOperationFailed e) when(e.InnerException is not null)
         {
             activity?.RecordError(e.InnerException);
-            throw;
+            // ReSharper disable once PossibleIntendedRethrow
+#pragma warning disable CA2200
+            // Here we would like the stacktrace to be updated with this stack instead of the actor stack
+            throw e;
+#pragma warning restore CA2200
         }
         catch (Exception e)
         {

--- a/Source/Aggregates/AggregateRootOperations.cs
+++ b/Source/Aggregates/AggregateRootOperations.cs
@@ -65,6 +65,11 @@ public class AggregateRootOperations<TAggregate> : IAggregateRootOperations<TAgg
                 throw result.Exception;
             }
         }
+        catch (AggregateRootOperationFailed e) when(e.InnerException is not null)
+        {
+            activity?.RecordError(e.InnerException);
+            throw;
+        }
         catch (Exception e)
         {
             activity?.RecordError(e);


### PR DESCRIPTION
## Summary
Reduces some overhead by reducing duplicate tracing of event handling. Fixed an issue where both the client and actor would wrap the exception in AggregateRootOperationFailed

### Changed
- Removed duplicate event traces (avoid tracing HandleEventRequest).

### Fixed
- Avoids wrapping AggregateRootOperationFailed in an AggregateRootOperationFailed.