### PR TITLE
Aggregate analyzers improvements

### DIFF
--- a/Benchmarks/SDK/SDK.csproj
+++ b/Benchmarks/SDK/SDK.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Source/Analyzers/AggregateAnalyzer.cs
+++ b/Source/Analyzers/AggregateAnalyzer.cs
@@ -167,12 +167,28 @@ public class AggregateAnalyzer : DiagnosticAnalyzer
                 .OfType<InvocationExpressionSyntax>()
                 .Where(invocation => invocation.Expression is IdentifierNameSyntax { Identifier.Text: "Apply" })
                 .ToArray();
-
+            
             foreach (var applyInvocation in applyInvocations)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     DescriptorRules.Aggregate.MutationsCannotProduceEvents,
                     applyInvocation.GetLocation(),
+                    new[] { onMethod.ToDisplayString() }
+                ));
+            }
+            
+            var memberApplyInvocations = syntax
+                .DescendantNodes()
+                .OfType<MemberAccessExpressionSyntax>()
+                .Where(memberAccess => memberAccess.Name is IdentifierNameSyntax { Identifier.Text: "Apply" })
+                .Where(memberAccess => memberAccess.Name is IdentifierNameSyntax { Identifier.Text: "Apply" } && memberAccess.Expression is ThisExpressionSyntax or BaseExpressionSyntax)
+                .ToArray();
+            
+            foreach (var invocation in memberApplyInvocations)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DescriptorRules.Aggregate.MutationsCannotProduceEvents,
+                    invocation.GetLocation(),
                     new[] { onMethod.ToDisplayString() }
                 ));
             }

--- a/Source/Analyzers/Analyzers.csproj
+++ b/Source/Analyzers/Analyzers.csproj
@@ -7,11 +7,12 @@
         <RootNamespace>Dolittle.SDK.Analyzers</RootNamespace>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     </PropertyGroup>
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Analyzers/DescriptorRules.cs
+++ b/Source/Analyzers/DescriptorRules.cs
@@ -81,5 +81,14 @@ static class DescriptorRules
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
                 description: "Change the On-method to take a single event as a parameter");
+
+        internal static readonly DiagnosticDescriptor MutationsCannotProduceEvents = new(
+            DiagnosticIds.AggregateMutationsCannotProduceEvents,
+            "Apply method should not be called within On method",
+            "Apply method should not be called within On method in aggregates as they are NOT allowed to produce new events",
+            DiagnosticCategories.Sdk,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true
+        );
     }
 }

--- a/Source/Analyzers/DiagnosticIds.cs
+++ b/Source/Analyzers/DiagnosticIds.cs
@@ -36,7 +36,12 @@ public static class DiagnosticIds
     public const string AggregateMutationHasIncorrectNumberOfParametersRuleId = "AGG0003";
 
     /// <summary>
-    /// Aggregate on-method has an incorrect number of parameters
+    /// Aggregate On-method has an incorrect number of parameters
     /// </summary>
     public const string AggregateMutationShouldBePrivateRuleId = "AGG0004";
+    
+    /// <summary>
+    /// Apply can not be used in an On-method. 
+    /// </summary>
+    public const string AggregateMutationsCannotProduceEvents = "AGG0005";
 }

--- a/Tests/Analyzers/Analyzers.csproj
+++ b/Tests/Analyzers/Analyzers.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />

--- a/Tests/Analyzers/Diagnostics/AggregateAnalyzerTests.cs
+++ b/Tests/Analyzers/Diagnostics/AggregateAnalyzerTests.cs
@@ -359,4 +359,50 @@ class SomeAggregate: AggregateRoot
 
         await VerifyAnalyzerAsync(test, expected);
     }
+    
+    [Fact]
+    public async Task ShouldFindApplyInOnMethod()
+    {
+        var test = @"
+using Dolittle.SDK.Aggregates;
+using Dolittle.SDK.Events;
+
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+record NameUpdated(string Name);
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3c"")]
+record InvalidThingHappening(string Name);
+
+[AggregateRoot(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeAggregate: AggregateRoot
+{
+    public string Name {get; set;}
+
+    public void UpdateName(string name)
+    {
+        Apply(new NameUpdated(name));
+    }
+
+    void On(NameUpdated @event)
+    {
+        Name = @event.Name;
+        Apply(new InvalidThingHappening(""This should not be here""));
+    }
+
+    void On(InvalidThingHappening @event)
+    {
+        Name = @event.Name;
+    }
+}";
+
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.Aggregate.MutationsCannotProduceEvents)
+                .WithSpan(25, 9, 25, 68)
+                .WithArguments("Apply(new InvalidThingHappening(\"This should not be here\"))")
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
 }

--- a/Tests/Analyzers/Diagnostics/AggregateAnalyzerTests.cs
+++ b/Tests/Analyzers/Diagnostics/AggregateAnalyzerTests.cs
@@ -359,7 +359,7 @@ class SomeAggregate: AggregateRoot
 
         await VerifyAnalyzerAsync(test, expected);
     }
-    
+
     [Fact]
     public async Task ShouldFindApplyInOnMethod()
     {
@@ -405,4 +405,133 @@ class SomeAggregate: AggregateRoot
 
         await VerifyAnalyzerAsync(test, expected);
     }
+    
+    [Fact]
+    public async Task ShouldFindApplyInOnMethodWithThis()
+    {
+        var test = @"
+using Dolittle.SDK.Aggregates;
+using Dolittle.SDK.Events;
+
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+record NameUpdated(string Name);
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3c"")]
+record InvalidThingHappening(string Name);
+
+[AggregateRoot(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeAggregate: AggregateRoot
+{
+    public string Name {get; set;}
+
+    public void UpdateName(string name)
+    {
+        Apply(new NameUpdated(name));
+    }
+
+    void On(NameUpdated @event)
+    {
+        Name = @event.Name;
+        this.Apply(new InvalidThingHappening(""This should not be here""));
+    }
+
+    void On(InvalidThingHappening @event)
+    {
+        Name = @event.Name;
+    }
+}";
+
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.Aggregate.MutationsCannotProduceEvents)
+                .WithSpan(25, 9, 25, 19)
+                .WithArguments("Apply(new InvalidThingHappening(\"This should not be here\"))")
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+    
+    [Fact]
+    public async Task ShouldFindApplyInOnMethodWithBase()
+    {
+        var test = @"
+using Dolittle.SDK.Aggregates;
+using Dolittle.SDK.Events;
+
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+record NameUpdated(string Name);
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3c"")]
+record InvalidThingHappening(string Name);
+
+[AggregateRoot(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeAggregate: AggregateRoot
+{
+    public string Name {get; set;}
+
+    public void UpdateName(string name)
+    {
+        Apply(new NameUpdated(name));
+    }
+
+    void On(NameUpdated @event)
+    {
+        Name = @event.Name;
+        base.Apply(new InvalidThingHappening(""This should not be here""));
+    }
+
+    void On(InvalidThingHappening @event)
+    {
+        Name = @event.Name;
+    }
+}";
+
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.Aggregate.MutationsCannotProduceEvents)
+                .WithSpan(25, 9, 25, 19)
+                .WithArguments("Apply(new InvalidThingHappening(\"This should not be here\"))")
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ShouldNotFindApplyWhenTargetIsNotAggregate()
+    {
+        var test = @"
+using Dolittle.SDK.Aggregates;
+using Dolittle.SDK.Events;
+
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+record NameUpdated(string Name){
+    public void Apply(){
+        System.Console.WriteLine(""Not relevant"");
+    }
+}
+
+
+[AggregateRoot(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeAggregate: AggregateRoot
+{
+    public string Name {get; set;}
+
+    public void UpdateName(string name)
+    {
+        Apply(new NameUpdated(name));
+    }
+
+    void On(NameUpdated @event)
+    {
+        Name = @event.Name;
+        @event.Apply();
+    }
+}";
+
+        await VerifyAnalyzerFindsNothingAsync(test);
+    }
+    
 }


### PR DESCRIPTION
## Summary

Added analyzer to guard against bugs where new events are produced in an `On` method. These should only update the internal state of the aggregate, not produce new events.

### Added

- Check against `Apply` used in aggregate `On` methods