### PR TITLE
Improved control over aggregate operations timing

### DIFF
--- a/Source/Aggregates/Actors/AggregateClusterKindFactory.cs
+++ b/Source/Aggregates/Actors/AggregateClusterKindFactory.cs
@@ -30,6 +30,6 @@ static class AggregateClusterKindFactory<TAggregate> where TAggregate : Aggregat
         var idleUnloadTimeout = serviceProvider.GetRequiredService<AggregateUnloadTimeout>()();
 
         return new ClusterKind(aggregateRootType.Id.Value.ToString(),
-            Props.FromProducer(() => new AggregateActor<TAggregate>(providerForTenant, logger, idleUnloadTimeout)).WithClusterRequestDeduplication());
+            Props.FromProducer(() => new AggregateActor<TAggregate>(providerForTenant, logger, idleUnloadTimeout)).WithClusterRequestDeduplication(TimeSpan.FromMinutes(5)));
     }
 }

--- a/Source/Events.Handling/EventHandler.cs
+++ b/Source/Events.Handling/EventHandler.cs
@@ -76,8 +76,7 @@ public class EventHandler : IEventHandler
     public async Task Handle(object @event, EventType eventType, EventContext context, IServiceProvider serviceProvider, CancellationToken cancellation)
     {
         var time = Stopwatch.StartNew();
-        using var activity = @event is not HandleEventRequest ? context.CommittedExecutionContext.StartChildActivity($"{_activityName}{@event.GetType().Name}")
-            ?.Tag(eventType) : null;
+        using var activity = context.CommittedExecutionContext.StartChildActivity($"{_activityName}{@event.GetType().Name}");
 
         try
         {

--- a/Source/SDK/Builders/DolittleClientConfiguration.cs
+++ b/Source/SDK/Builders/DolittleClientConfiguration.cs
@@ -42,7 +42,13 @@ public class DolittleClientConfiguration : IConfigurationBuilder
     /// <summary>
     /// How long should the aggregates be kept in memory when not in use.
     /// </summary>
-    public TimeSpan AggregateIdleTimeout { get; private set; } = TimeSpan.FromSeconds(20);
+    public TimeSpan AggregateIdleTimeout { get; private set; } = TimeSpan.FromSeconds(30);
+    
+    /// <summary>
+    /// The default timeout for performing an aggregate operation (potentially including hydration & commits).
+    /// If no CancellationToken is provided, this timeout will be used.
+    /// </summary>
+    public TimeSpan? DefaultAggregatePerformTimeout { get; private set; }
 
     /// <summary>
     /// Gets the event serializer provider.
@@ -193,6 +199,13 @@ public class DolittleClientConfiguration : IConfigurationBuilder
     public IConfigurationBuilder WithAggregateIdleTimout(TimeSpan timeout)
     {
         AggregateIdleTimeout = timeout;
+        return this;
+    }
+    
+    /// <inheritdoc />
+    public IConfigurationBuilder WithDefaultAggregatePerformTimeout(TimeSpan timeout)
+    {
+        DefaultAggregatePerformTimeout = timeout;
         return this;
     }
 

--- a/Source/SDK/Builders/IConfigurationBuilder.cs
+++ b/Source/SDK/Builders/IConfigurationBuilder.cs
@@ -69,6 +69,15 @@ public interface IConfigurationBuilder
     public IConfigurationBuilder WithAggregateIdleTimout(TimeSpan timeout);
 
     /// <summary>
+    /// Sets the default timeout for performing an aggregate operation (potentially including hydration & commits).
+    /// If no CancellationToken is provided, this timeout will be used.
+    /// Not set by default
+    /// </summary>
+    /// <param name="timeout"></param>
+    /// <returns></returns>
+    public IConfigurationBuilder WithDefaultAggregatePerformTimeout(TimeSpan timeout);
+    
+    /// <summary>
     /// Configures the root <see cref="IServiceProvider"/> for the <see cref="IDolittleClient"/>.
     /// </summary>
     /// <param name="serviceProvider">The <see cref="IDolittleClient"/>.</param>

--- a/Source/SDK/Proto/ServiceCollectionExtensions.cs
+++ b/Source/SDK/Proto/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Dolittle.SDK.Aggregates;
 using Dolittle.SDK.Aggregates.Actors;
 using Dolittle.SDK.Builders;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,6 +41,21 @@ static class ServiceCollectionExtensions
                 var timeout = dolittleClientConfiguration.AggregateIdleTimeout;
 
                 return () => timeout;
+            })
+            .AddSingleton<DefaultAggregatePerformTimeout>(sp =>
+            {
+                var dolittleClientConfiguration = sp.GetRequiredService<DolittleClientConfiguration>();
+                var timeout = dolittleClientConfiguration.DefaultAggregatePerformTimeout;
+                if (timeout is not null)
+                {
+                    var seconds = (int)Math.Ceiling(timeout.Value.TotalSeconds);
+                    if (seconds > 0)
+                    {
+                        return () => CancellationTokens.FromSeconds(seconds);
+                    }
+                }
+
+                return () => default;
             });
     }
 


### PR DESCRIPTION
## Summary

This solves for timing issues with VERY large aggregates. Normally this will not be necessary, but if aggregates are very long and take a long time to rehydrate, this will let them still work correctly. In addition, added `DefaultAggregatePerformTimeout `which can be set globally to time out perform requests if they are extremely slow. 

### Added
- `DefaultAggregatePerformTimeout`

### Removed
- Duplicate tracing of event handlers

