### PR TITLE
EventHandler improvements

### DIFF
--- a/Source/Analyzers/AnalysisExtensions.cs
+++ b/Source/Analyzers/AnalysisExtensions.cs
@@ -125,4 +125,5 @@ static class AnalysisExtensions
     {
         return attributeArgument.NameColon?.Name.Identifier.Text == parameterName;
     }
+    
 }

--- a/Source/Analyzers/CodeFixes/EventHandlerEventContextCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/EventHandlerEventContextCodeFixProvider.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Dolittle.SDK.Analyzers.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AttributeMissingCodeFixProvider)), Shared]
+public class EventHandlerEventContextCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+        DiagnosticIds.EventHandlerMissingEventContext
+    );
+
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var document = context.Document;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            switch (diagnostic.Id)
+            {
+                case DiagnosticIds.EventHandlerMissingEventContext:
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            "Add EventContext parameter",
+                            ct => AddEventContextParameter(context, diagnostic, document, ct),
+                            nameof(EventHandlerEventContextCodeFixProvider) + ".AddEventContext"),
+                        diagnostic);
+                    break;
+            }
+        }
+
+
+        return Task.CompletedTask;
+    }
+
+    async Task<Document> AddEventContextParameter(CodeFixContext context, Diagnostic diagnostic, Document document, CancellationToken ct)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return document;
+
+        // Find the method declaration identified by the diagnostic.
+        var methodDeclaration = GetMethodDeclaration(root, diagnostic);
+        if (methodDeclaration is null)
+        {
+            return document;
+        }
+
+
+        var updatedRoot = root.ReplaceNode(methodDeclaration, WithEventContextParameter(methodDeclaration));
+        var newRoot = EnsureNamespaceImported((CompilationUnitSyntax)updatedRoot, "Dolittle.SDK.Events");
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    /// <summary>
+    /// Adds EventContext parameter to the method declaration
+    /// </summary>
+    /// <param name="methodDeclaration"></param>
+    /// <returns></returns>
+    MethodDeclarationSyntax WithEventContextParameter(MethodDeclarationSyntax methodDeclaration)
+    {
+        var existingParameters = methodDeclaration.ParameterList.Parameters;
+        // Get the first parameter that is not the EventContext parameter
+        var eventParameter = existingParameters.FirstOrDefault(parameter => parameter.Type?.ToString() != "EventContext");
+        if (eventParameter is null)
+        {
+            return methodDeclaration;
+        }
+
+
+        var eventContextParameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier("ctx")).WithType(SyntaxFactory.ParseTypeName("EventContext"));
+
+        var originalParameterList = methodDeclaration.ParameterList;
+        var newParameterList = SyntaxFactory.ParameterList(
+                SyntaxFactory.SeparatedList(
+                    new[]
+                    {
+                        eventParameter,
+                        eventContextParameter
+                    }
+                )
+            ).WithLeadingTrivia(originalParameterList.GetLeadingTrivia())
+            .WithTrailingTrivia(originalParameterList.GetTrailingTrivia());
+        return methodDeclaration.WithParameterList(newParameterList);
+    }
+
+    MethodDeclarationSyntax? GetMethodDeclaration(SyntaxNode root, Diagnostic diagnostic)
+    {
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+        var methodDeclaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
+        return methodDeclaration;
+    }
+
+    public static CompilationUnitSyntax EnsureNamespaceImported(CompilationUnitSyntax root, string namespaceToInclude)
+    {
+        var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceToInclude));
+        var existingUsings = root.Usings;
+
+        if (existingUsings.Any(u => u.Name?.ToFullString() == namespaceToInclude))
+        {
+            // Namespace is already imported.
+            return root;
+        }
+        var lineEndingTrivia = root.DescendantTrivia().First(_ => _.IsKind(SyntaxKind.EndOfLineTrivia));
+        usingDirective = usingDirective.WithTrailingTrivia(lineEndingTrivia);
+
+        return root.WithUsings(existingUsings.Add(usingDirective));
+    }
+}

--- a/Source/Analyzers/DescriptorRules.cs
+++ b/Source/Analyzers/DescriptorRules.cs
@@ -90,5 +90,14 @@ static class DescriptorRules
             DiagnosticSeverity.Error,
             isEnabledByDefault: true
         );
+        
+        internal static readonly DiagnosticDescriptor PublicMethodsCannotMutateAggregateState = new(
+            DiagnosticIds.PublicMethodsCannotMutateAggregateState,
+            "Aggregates should only be mutated with events",
+            "Public methods can not mutate the state of an aggregate. All mutations needs to be done via events.",
+            DiagnosticCategories.Sdk,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true
+        );
     }
 }

--- a/Source/Analyzers/DescriptorRules.cs
+++ b/Source/Analyzers/DescriptorRules.cs
@@ -7,6 +7,26 @@ namespace Dolittle.SDK.Analyzers;
 
 static class DescriptorRules
 {
+    internal static readonly DiagnosticDescriptor InvalidTimestamp =
+        new(
+            DiagnosticIds.InvalidTimestampParameter,
+            title: "Invalid DateTimeOffset format",
+            messageFormat: "Value '{0}' should be a valid DateTimeOffset",
+            DiagnosticCategories.Sdk,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "The value should be a valid DateTimeOffset.");
+    
+    internal static readonly DiagnosticDescriptor InvalidStartStopTimestamp =
+        new(
+            DiagnosticIds.InvalidStartStopTime,
+            title: "Start is not before stop",
+            messageFormat: "'{0}' should be before '{1}'",
+            DiagnosticCategories.Sdk,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "Start timestamp should be before stop timestamp.");
+    
     internal static readonly DiagnosticDescriptor InvalidIdentity =
         new(
             DiagnosticIds.AttributeInvalidIdentityRuleId,
@@ -26,7 +46,17 @@ static class DescriptorRules
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "Assign a unique identity in the attribute");
-    
+
+    internal static readonly DiagnosticDescriptor InvalidAccessibility = 
+        new(
+            DiagnosticIds.InvalidAccessibility,
+            title: "Invalid accessibility level",
+            messageFormat: "{0} needs to be '{1}'",
+            DiagnosticCategories.Sdk,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Change the accessibility level to '{1}'.");
+
     internal static class Events
     {
         internal static readonly DiagnosticDescriptor MissingAttribute =
@@ -38,6 +68,16 @@ static class DescriptorRules
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
                 description: "Mark the event with an EventTypeAttribute and assign an identifier to it");
+        
+        internal static readonly DiagnosticDescriptor MissingEventContext =
+            new(
+                DiagnosticIds.EventHandlerMissingEventContext,
+                title: "Handle method does not take EventContext as the second parameter",
+                messageFormat: "{0} is missing EventContext argument",
+                DiagnosticCategories.Sdk,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                description: "Add the EventContext as the second parameter to the Handle method");
     }
 
     internal static class Aggregate

--- a/Source/Analyzers/DiagnosticIds.cs
+++ b/Source/Analyzers/DiagnosticIds.cs
@@ -44,4 +44,10 @@ public static class DiagnosticIds
     /// Apply can not be used in an On-method. 
     /// </summary>
     public const string AggregateMutationsCannotProduceEvents = "AGG0005";
+    
+    /// <summary>
+    /// Public methods can not mutate the state of an aggregate.
+    /// All mutations need to be done in On-methods.
+    /// </summary>
+    public const string PublicMethodsCannotMutateAggregateState = "AGG0006";
 }

--- a/Source/Analyzers/DiagnosticIds.cs
+++ b/Source/Analyzers/DiagnosticIds.cs
@@ -21,6 +21,20 @@ public static class DiagnosticIds
     public const string IdentityIsNotUniqueRuleId = "SDK0003";
 
     /// <summary>
+    /// Invalid timestamp.
+    /// </summary>
+    public const string InvalidTimestampParameter = "SDK0004";
+    
+    /// <summary>
+    /// Invalid timestamp.
+    /// </summary>
+    public const string InvalidStartStopTime = "SDK0005";
+
+    public const string InvalidAccessibility = "SDK0006";
+    
+    public const string EventHandlerMissingEventContext = "SDK0007";
+    
+    /// <summary>
     /// Aggregate missing the required Attribute.
     /// </summary>
     public const string AggregateMissingAttributeRuleId = "AGG0001";
@@ -50,4 +64,6 @@ public static class DiagnosticIds
     /// All mutations need to be done in On-methods.
     /// </summary>
     public const string PublicMethodsCannotMutateAggregateState = "AGG0006";
+    
+
 }

--- a/Source/Analyzers/DolittleTypes.cs
+++ b/Source/Analyzers/DolittleTypes.cs
@@ -12,5 +12,7 @@ static class DolittleTypes
     
     public const string ICommitEventsInterface = "Dolittle.SDK.Events.Store.ICommitEvents";
     
+    public const string EventContext = "Dolittle.SDK.Events.EventContext";
+    
     
 }

--- a/Source/Analyzers/EventHandlerAnalyzer.cs
+++ b/Source/Analyzers/EventHandlerAnalyzer.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Dolittle.SDK.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class EventHandlerAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        DescriptorRules.InvalidTimestamp,
+        DescriptorRules.InvalidStartStopTimestamp,
+        DescriptorRules.InvalidAccessibility,
+        DescriptorRules.Events.MissingAttribute,
+        DescriptorRules.Events.MissingEventContext
+        );
+
+    const int StartFromTimestampOffset = 6;
+    const int StopAtTimestampOffset = 7;
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(AnalyzeEventHandler, ImmutableArray.Create(SyntaxKind.ClassDeclaration));
+    }
+
+    void AnalyzeEventHandler(SyntaxNodeAnalysisContext context)
+    {
+        var classSyntax = (ClassDeclarationSyntax)context.Node;
+        var classSymbol = context.SemanticModel.GetDeclaredSymbol(classSyntax);
+        if (classSymbol is null || !classSymbol.HasAttribute(DolittleTypes.EventHandlerAttribute))
+        {
+            return;
+        }
+
+        AnalyzeEventHandlerAttribute(context, classSymbol);
+        AnalyzeHandleMethods(context, classSymbol);
+    }
+
+    void AnalyzeHandleMethods(SyntaxNodeAnalysisContext context, INamedTypeSymbol classSymbol)
+    {
+        var handleMethods = classSymbol.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(method => method.Name == "Handle");
+
+        foreach (var handleMethod in handleMethods)
+        {
+            AnalyzeHandleMethod(context, handleMethod);
+        }
+    }
+
+    void AnalyzeHandleMethod(SyntaxNodeAnalysisContext context, IMethodSymbol handleMethod)
+    {
+        // Check that it is public
+        if (!handleMethod.DeclaredAccessibility.HasFlag(Accessibility.Public))
+        {
+            var diagnostic = Diagnostic.Create(DescriptorRules.InvalidAccessibility, handleMethod.Locations[0], handleMethod.Name, Accessibility.Public);
+            context.ReportDiagnostic(diagnostic);
+        }
+        
+        // Get the first parameter and get the type
+        var parameter = handleMethod.Parameters.FirstOrDefault();
+        if (parameter is null)
+        {
+            return;
+        }
+        // Check if the type has the EventType attribute
+        if (!parameter.Type.HasEventTypeAttribute())
+        {
+            var diagnostic = Diagnostic.Create(DescriptorRules.Events.MissingAttribute, parameter.Locations[0],
+                parameter.Type.ToTargetClassAndAttributeProps(DolittleTypes.EventTypeAttribute), parameter.Type.Name);
+            context.ReportDiagnostic(diagnostic);
+        }
+        
+        // Check that the method takes an EventContext as the second parameter
+        var secondParameter = handleMethod.Parameters.Skip(1).FirstOrDefault();
+        if(secondParameter is null || secondParameter.Type.ToString() != DolittleTypes.EventContext)
+        {
+            var diagnostic = Diagnostic.Create(DescriptorRules.Events.MissingEventContext, handleMethod.Locations[0], handleMethod.Name);
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    static void AnalyzeEventHandlerAttribute(SyntaxNodeAnalysisContext context, INamedTypeSymbol classSymbol)
+    {
+        var eventHandlerAttribute = classSymbol.GetAttributes()
+            .Single(attribute => attribute.AttributeClass?.ToDisplayString() == DolittleTypes.EventHandlerAttribute);
+        if (eventHandlerAttribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) is not AttributeSyntax attributeSyntaxNode)
+        {
+            return;
+        }
+
+        AnalyzeEventHandlerStartFromStopAt(context, eventHandlerAttribute, attributeSyntaxNode);
+    }
+
+
+    static void AnalyzeEventHandlerStartFromStopAt(SyntaxNodeAnalysisContext context, AttributeData eventHandlerAttribute, AttributeSyntax syntaxNode)
+    {
+        var startFrom = GetAttributeArgument(eventHandlerAttribute, syntaxNode, StartFromTimestampOffset, "startFromTimestamp");
+        if (startFrom?.value is not null && !DateTimeOffset.TryParse(startFrom.Value.value.ToString(), out var parsedStartFrom))
+        {
+            var diagnostic = Diagnostic.Create(DescriptorRules.InvalidTimestamp, startFrom.Value.location, "startFromTimestamp");
+            context.ReportDiagnostic(diagnostic);
+        }
+
+        var stopAt = GetAttributeArgument(eventHandlerAttribute, syntaxNode, StopAtTimestampOffset, "stopAtTimestamp");
+        if (stopAt?.value is not null && !DateTimeOffset.TryParse(stopAt.Value.value.ToString(), out var parsedStopAt))
+        {
+            var diagnostic = Diagnostic.Create(DescriptorRules.InvalidTimestamp, stopAt.Value.location, "stopAtTimestamp");
+            context.ReportDiagnostic(diagnostic);
+        }
+        
+        if(parsedStartFrom > DateTimeOffset.MinValue && parsedStopAt > DateTimeOffset.MinValue && parsedStartFrom >= parsedStopAt)
+        {
+            var diagnostic = Diagnostic.Create(DescriptorRules.InvalidStartStopTimestamp, syntaxNode.GetLocation(), "startFromTimestamp", "stopAtTimestamp");
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    public static (object? value, Location location)? GetAttributeArgument(AttributeData eventHandlerAttribute, AttributeSyntax syntaxNode, int offset,
+        string argumentName)
+    {
+        if (syntaxNode.ArgumentList is null)
+        {
+            return null;
+        }
+
+        // Handle positional arguments
+        if (offset > eventHandlerAttribute.ConstructorArguments.Length)
+        {
+            return null;
+        }
+
+        var argument = eventHandlerAttribute.ConstructorArguments[offset];
+
+        foreach (var argumentSyntax in syntaxNode.ArgumentList.Arguments)
+        {
+            if (argumentSyntax.NameColon?.Name?.Identifier.Text.Equals(argumentName, StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return (argument.Value, argumentSyntax.GetLocation());
+            }
+        }
+
+        if (syntaxNode.ArgumentList.Arguments.Count > offset)
+        {
+            var positionalSyntax = syntaxNode.ArgumentList.Arguments[offset];
+            return (argument.Value, positionalSyntax.GetLocation());
+        }
+        
+        return (argument.Value, syntaxNode.GetLocation());
+    }
+}

--- a/Source/Events.Handling/Builder/EventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/EventHandlerBuilder.cs
@@ -21,6 +21,9 @@ public class EventHandlerBuilder : IEventHandlerBuilder, ICanTryBuildEventHandle
     bool _partitioned = true;
     int _concurrency = 1;
     ScopeId _scopeId = ScopeId.Default;
+    ProcessFrom _resetTo;
+    DateTimeOffset? _startFrom;
+    DateTimeOffset? _stopAt;
     EventHandlerAlias? _alias;
 
     /// <summary>
@@ -39,7 +42,7 @@ public class EventHandlerBuilder : IEventHandlerBuilder, ICanTryBuildEventHandle
     /// <summary>
     /// Gets the <see cref="EventHandlerModelId"/>.
     /// </summary>
-    public EventHandlerModelId ModelId => new(_eventHandlerId, _partitioned, _scopeId, alias: _alias?.Value, concurrency: _concurrency);
+    public EventHandlerModelId ModelId => new(_eventHandlerId, _partitioned, _scopeId, alias: _alias?.Value, concurrency: _concurrency,_resetTo, _startFrom, _stopAt);
 
     /// <inheritdoc />
     public IEventHandlerMethodsBuilder Partitioned()
@@ -86,6 +89,34 @@ public class EventHandlerBuilder : IEventHandlerBuilder, ICanTryBuildEventHandle
         Bind();
         return this;
     }
+
+    /// <inheritdoc />
+    public IEventHandlerBuilder StartFrom(ProcessFrom processFrom)
+    {
+        Unbind();
+        _resetTo = processFrom;
+        Bind();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IEventHandlerBuilder StartFrom(DateTimeOffset processFrom)
+    {
+        Unbind();
+        _startFrom = processFrom;
+        Bind();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IEventHandlerBuilder StopAt(DateTimeOffset stopAt)
+    {
+        Unbind();
+        _stopAt = stopAt;
+        Bind();
+        return this;
+    }
+
 
     /// <inheritdoc />
     public bool TryBuild(EventHandlerModelId identifier, IEventTypes eventTypes, IClientBuildResults buildResults, out IEventHandler eventHandler)

--- a/Source/Events.Handling/Builder/IEventHandlerBuilder.cs
+++ b/Source/Events.Handling/Builder/IEventHandlerBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Dolittle.SDK.Events.Handling.Builder.Methods;
 
 namespace Dolittle.SDK.Events.Handling.Builder;
@@ -41,4 +42,27 @@ public interface IEventHandlerBuilder
     /// <param name="alias">The <see cref="EventHandlerAlias" />.</param>
     /// <returns>The builder for continuation.</returns>
     IEventHandlerBuilder WithAlias(EventHandlerAlias alias);
+    
+    /// <summary>
+    /// Set where in the stream the event handler starts if it has no state
+    /// </summary>
+    /// <param name="processFrom"></param>
+    /// <returns></returns>
+    IEventHandlerBuilder StartFrom(ProcessFrom processFrom);
+    
+    /// <summary>
+    /// Set when in the stream the event handler starts if it has no state.
+    /// Overrides <see cref="StartFrom(ProcessFrom)"/> if set
+    /// </summary>
+    /// <param name="processFrom">Timestamp to start processing from</param>
+    /// <returns></returns>
+    IEventHandlerBuilder StartFrom(DateTimeOffset processFrom);
+    
+    /// <summary>
+    /// Optional
+    /// If the event handler should not process newer events than the given timestamp, this can be set.
+    /// </summary>
+    /// <param name="stopAt"></param>
+    /// <returns></returns>
+    IEventHandlerBuilder StopAt(DateTimeOffset stopAt);
 }

--- a/Source/Events.Handling/EventHandler.cs
+++ b/Source/Events.Handling/EventHandler.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Diagnostics;
-using Dolittle.Runtime.Events.Processing.Contracts;
 using Dolittle.SDK.Diagnostics.OpenTelemetry;
 using Dolittle.SDK.Events.Handling.Builder.Methods;
 using Dolittle.SDK.Execution;

--- a/Source/Events.Handling/EventHandlerAttribute.cs
+++ b/Source/Events.Handling/EventHandlerAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
 using Dolittle.SDK.Common.Model;
 
 namespace Dolittle.SDK.Events.Handling;
@@ -23,35 +24,39 @@ public class EventHandlerAttribute : Attribute, IDecoratedTypeDecorator<EventHan
     /// <param name="inScope">The scope that the event handler handles events in.</param>
     /// <param name="alias">The alias for the event handler.</param>
     /// <param name="concurrency">How many events can be processed simultaneously</param>
-    // /// <param name="resetTo">Where to start processing if the event handler does not have state. Defaults to the first event in the log.</param>
-    // /// <param name="startFrom">Determines a specific event timestamp to start at if set. Overrides resetTo when used.</param>
-    // /// <param name="stopAt">Determines a specific event timestamp to stop processing at if set.</param>
+    /// <param name="startFrom">Where in the event log to start processing if the event handler has not been used before. Defaults to the first event.</param>
+    /// <param name="startFromTimestamp">Determines a specific event timestamp to start at if set. Overrides startFrom when used. Format is ISO 8601</param>
+    /// <param name="stopAtTimestamp">Determines a specific event timestamp to stop processing at if set. Format is ISO 8601</param>
     public EventHandlerAttribute(
         string eventHandlerId,
         bool partitioned = true,
         string? inScope = null,
         string? alias = null,
-        int concurrency = 1
-        // ,
-        // ProcessFrom resetTo = ProcessFrom.First,
-        // string? startFrom = null,
-        // string? stopAt = null
-        )
+        int concurrency = 1,
+        ProcessFrom startFrom = ProcessFrom.Earliest,
+        string? startFromTimestamp = null,
+        string? stopAtTimestamp = null
+    )
     {
         _eventHandlerId = eventHandlerId;
         _alias = alias;
         Concurrency = concurrency;
-        // ResetTo = resetTo;
-        // StartFrom = startFrom;
-        // StopAt = stopAt;
+        StartFrom = startFrom;
+        StartFromTimestamp = string.IsNullOrWhiteSpace(startFromTimestamp) ? null : DateTimeOffset.Parse(startFromTimestamp, CultureInfo.InvariantCulture);
+        StopAtTimestamp = string.IsNullOrWhiteSpace(stopAtTimestamp) ? null : DateTimeOffset.Parse(stopAtTimestamp, CultureInfo.InvariantCulture);
+        if (startFromTimestamp is not null && stopAtTimestamp is not null && StartFromTimestamp >= StopAtTimestamp)
+        {
+            throw new ArgumentException("StartFromTimestamp must be before StopAtTimestamp");
+        }
+
         Partitioned = partitioned;
         Scope = inScope ?? ScopeId.Default;
     }
 
     public int Concurrency { get; set; }
-    // public ProcessFrom ResetTo { get; }
-    // public string? StartFrom { get; }
-    // public string? StopAt { get; }
+    public ProcessFrom StartFrom { get; }
+    public DateTimeOffset? StartFromTimestamp { get; }
+    public DateTimeOffset? StopAtTimestamp { get; }
 
     /// <summary>
     /// Gets a value indicating whether this event handler is partitioned.
@@ -67,8 +72,8 @@ public class EventHandlerAttribute : Attribute, IDecoratedTypeDecorator<EventHan
     /// <inheritdoc />
     public EventHandlerModelId GetIdentifier(Type decoratedType)
     {
-        DateTimeOffset? startFrom = null;
-        DateTimeOffset? stopAt = null;
+        // DateTimeOffset? startFrom = null;
+        // DateTimeOffset? stopAt = null;
         // if (!string.IsNullOrWhiteSpace(StartFrom))
         // {
         //     startFrom = DateTimeOffset.Parse(StartFrom, DateTimeFormatInfo.InvariantInfo);
@@ -78,6 +83,6 @@ public class EventHandlerAttribute : Attribute, IDecoratedTypeDecorator<EventHan
         //     stopAt = DateTimeOffset.Parse(StopAt, DateTimeFormatInfo.InvariantInfo);
         // }
 
-        return new(_eventHandlerId, Partitioned, Scope, _alias ?? decoratedType.Name, Concurrency, ProcessFrom.First, startFrom, stopAt);
+        return new(_eventHandlerId, Partitioned, Scope, _alias ?? decoratedType.Name, Concurrency, StartFrom, StartFromTimestamp, StopAtTimestamp);
     }
 }

--- a/Source/Events.Handling/EventHandlerModelId.cs
+++ b/Source/Events.Handling/EventHandlerModelId.cs
@@ -27,8 +27,8 @@ public class EventHandlerModelId : Identifier<EventHandlerId, ScopeId>
         bool partitioned,
         ScopeId scope,
         string? alias,
-        int concurrency = 1,
-        ProcessFrom resetTo = ProcessFrom.First,
+        int concurrency,
+        ProcessFrom resetTo,
         DateTimeOffset? startFrom = null,
         DateTimeOffset? stopAt = null)
         : base("EventHandler", id, alias, scope)

--- a/Source/Events.Handling/Internal/EventHandlerProcessor.cs
+++ b/Source/Events.Handling/Internal/EventHandlerProcessor.cs
@@ -58,6 +58,10 @@ public class EventHandlerProcessor : EventProcessor<EventHandlerId, EventHandler
                 registrationRequest.Alias = _eventHandler.Alias!.Value;
             }
 
+            if (_eventHandler.StopAt.HasValue)
+            {
+                registrationRequest.StopAt = Timestamp.FromDateTimeOffset(_eventHandler.StopAt.Value);
+            }
             registrationRequest.EventTypes.AddRange(_eventHandler.HandledEvents.Select(_ => _.ToProtobuf()).ToArray());
             return registrationRequest;
         }
@@ -75,7 +79,7 @@ public class EventHandlerProcessor : EventProcessor<EventHandlerId, EventHandler
 
         return new StartFrom
         {
-            Position = eventHandler.ResetTo == ProcessFrom.Last ? StartFrom.Types.Position.Latest : StartFrom.Types.Position.Start
+            Position = eventHandler.ResetTo == ProcessFrom.Latest ? StartFrom.Types.Position.Latest : StartFrom.Types.Position.Start
         };
     }
 

--- a/Source/Events.Handling/ProcessFrom.cs
+++ b/Source/Events.Handling/ProcessFrom.cs
@@ -11,9 +11,9 @@ public enum ProcessFrom
     /// <summary>
     ///   Start from the beginning of the stream, process all events.
     /// </summary>
-    First,
+    Earliest,
     /// <summary>
     /// Start after the latest event in the stream, only process new events.
     /// </summary>
-    Last
+    Latest
 }

--- a/Specifications/Events.Handling/for_EventHandler/when_creating.cs
+++ b/Specifications/Events.Handling/for_EventHandler/when_creating.cs
@@ -18,6 +18,8 @@ public class when_creating
     static IEnumerable<EventType> event_types;
     static IDictionary<EventType, IEventHandlerMethod> event_handler_methods;
     static EventHandler event_handler;
+    static int concurrency = 1;
+    static ProcessFrom reset_to = ProcessFrom.Earliest;
 
     Establish context = () =>
     {
@@ -36,7 +38,7 @@ public class when_creating
                 _ => new EventHandlerMethod((@event, eventContext) => Task.CompletedTask) as IEventHandlerMethod));
     };
 
-    Because of = () => event_handler = new EventHandler(new EventHandlerModelId(identifier, partitioned, scope_id, alias), event_handler_methods);
+    Because of = () => event_handler = new EventHandler(new EventHandlerModelId(identifier, partitioned, scope_id, alias, concurrency, reset_to), event_handler_methods);
 
     It should_not_be_null = () => event_handler.ShouldNotBeNull();
     It should_have_the_correct_partitioned_value = () => event_handler.Partitioned.ShouldEqual(partitioned);

--- a/Specifications/Events.Handling/for_EventHandler/when_handling/given/an_event_handler.cs
+++ b/Specifications/Events.Handling/for_EventHandler/when_handling/given/an_event_handler.cs
@@ -17,6 +17,8 @@ public class an_event_handler
     protected static Mock<IEventHandlerMethod> event_handler_method;
     protected static IDictionary<EventType, IEventHandlerMethod> event_handler_methods;
     protected static EventHandler event_handler;
+    protected static int concurrency = 1;
+    protected static ProcessFrom reset_to = ProcessFrom.Earliest;
 
     Establish context = () =>
     {
@@ -29,6 +31,6 @@ public class an_event_handler
         {
             { handled_event_type, event_handler_method.Object }
         };
-        event_handler = new EventHandler(new EventHandlerModelId(identifier, partitioned, scope_id, "some alias"), event_handler_methods);
+        event_handler = new EventHandler(new EventHandlerModelId(identifier, partitioned, scope_id, "some alias", concurrency, reset_to, null, null), event_handler_methods);
     };
 }

--- a/Tests/Analyzers/CodeFixProviderTests.cs
+++ b/Tests/Analyzers/CodeFixProviderTests.cs
@@ -18,6 +18,9 @@ public abstract class CodeFixProviderTests<TAnalyzer, TCodeFix> : AnalyzerTest<T
 {
     protected Task VerifyCodeFixAsync(string source, string expectedResult, DiagnosticResult diagnosticResult)
     {
+        source = ToLfLineEndings(source);
+        expectedResult = ToLfLineEndings(expectedResult);
+        
         var test = new CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
         {
             TestCode = source,
@@ -37,5 +40,10 @@ public abstract class CodeFixProviderTests<TAnalyzer, TCodeFix> : AnalyzerTest<T
         }
         
         return test.RunAsync(CancellationToken.None);
+    }
+
+    string ToLfLineEndings(string source)
+    {
+        return source.Replace("\r\n", "\n");
     }
 }

--- a/Tests/Analyzers/CodeFixes/EventHandlerEventContextCodeFixProviderTests.cs
+++ b/Tests/Analyzers/CodeFixes/EventHandlerEventContextCodeFixProviderTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Dolittle.SDK.Analyzers.CodeFixes;
+
+public class EventHandlerEventContextCodeFixProviderTests: CodeFixProviderTests<EventHandlerAnalyzer, EventHandlerEventContextCodeFixProvider>
+{
+    
+    [Fact]
+    public async Task ShouldGenerateEventContext()
+    {
+        var test = @"using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp: ""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    public void Handle(SomeEvent evt)
+    {
+        System.Console.WriteLine(""Hello World"");
+    }
+}";
+
+        var expected = @"using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp: ""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    public void Handle(SomeEvent evt, EventContext ctx)
+    {
+        System.Console.WriteLine(""Hello World"");
+    }
+}";
+
+        var diagnosticResult = Diagnostic(DescriptorRules.Events.MissingEventContext)
+            .WithSpan(10, 17, 10, 23)
+            .WithArguments("Handle");
+
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+    
+    [Fact]
+    public async Task ShouldGenerateEventContextAndNamespace()
+    {
+        var test = @"using Dolittle.SDK.Events.Handling;
+
+[Dolittle.SDK.Events.EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp: ""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    public void Handle(SomeEvent evt)
+    {
+        System.Console.WriteLine(""Hello World"");
+    }
+}";
+
+        var expected = @"using Dolittle.SDK.Events.Handling;
+using Dolittle.SDK.Events;
+
+[Dolittle.SDK.Events.EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp: ""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    public void Handle(SomeEvent evt, EventContext ctx)
+    {
+        System.Console.WriteLine(""Hello World"");
+    }
+}";
+
+        var diagnosticResult = Diagnostic(DescriptorRules.Events.MissingEventContext)
+            .WithSpan(9, 17, 9, 23)
+            .WithArguments("Handle");
+
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+}

--- a/Tests/Analyzers/Diagnostics/AnnotationAnalyzerTests.cs
+++ b/Tests/Analyzers/Diagnostics/AnnotationAnalyzerTests.cs
@@ -134,4 +134,23 @@ class SomeEvent
 
         await VerifyAnalyzerFindsNothingAsync(test);
     }
+    
+    [Fact]
+    public async Task ShouldDetectEventHandlerWhenQualified()
+    {
+        var test = @"
+[Dolittle.SDK.Events.Handling.EventHandler("""")]
+class SomeEvent
+{
+    public string Name {get; set;}
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.InvalidIdentity)
+                .WithSpan(2, 2, 2, 47)
+                .WithArguments("Dolittle.SDK.Events.Handling.EventHandler", "eventHandlerId", "\"\""),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
 }

--- a/Tests/Analyzers/Diagnostics/EventHandlerAnalyzerTests.cs
+++ b/Tests/Analyzers/Diagnostics/EventHandlerAnalyzerTests.cs
@@ -1,0 +1,269 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using System.Threading.Tasks;
+
+namespace Dolittle.SDK.Analyzers.Diagnostics;
+
+public class EventHandlerAnalyzerTests : AnalyzerTest<EventHandlerAnalyzer>
+{
+    [Fact]
+    public async Task ShouldDetectNothing()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp:""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    public void Handle(SomeEvent evt, EventContext context)
+    {
+    }
+}";
+        await VerifyAnalyzerFindsNothingAsync(test);
+    }
+    
+    [Fact]
+    public async Task ShouldDetectNothingAsync()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+using System.Threading.Tasks;
+
+[EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp:""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    public async Task Handle(SomeEvent evt, EventContext context)
+    {
+    }
+}";
+        await VerifyAnalyzerFindsNothingAsync(test);
+    }
+
+    [Fact]
+    public async Task ShouldDetectInvalidStartFromTimestamp()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, startFromTimestamp:""2023-09-15T07:30Z!"")]
+class SomeEventHandler
+{
+    
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.InvalidTimestamp)
+                .WithSpan(5, 86, 5, 125)
+                .WithArguments("startFromTimestamp"),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+    
+    [Fact]
+    public async Task ShouldDetectInvalidStopAtTimestamp()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp:""2023-09-15T07:30Z!"")]
+class SomeEventHandler
+{
+    
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.InvalidTimestamp)
+                .WithSpan(5, 86, 5, 122)
+                .WithArguments("stopAtTimestamp"),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+    
+    [Fact]
+    public async Task ShouldNotDetectDetectTimestampIssues()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFromTimestamp:""2023-09-15T06:25Z"", stopAtTimestamp:""2023-09-15T06:30Z"")]
+class SomeEventHandler
+{
+    
+}";
+
+        await VerifyAnalyzerFindsNothingAsync(test);
+
+    }
+    
+    [Fact]
+    public async Task ShouldDetectDetectTimestampIssues()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", stopAtTimestamp:""2023-09-15T06:25Z"", startFromTimestamp:""2023-09-15T06:30Z"")]
+class SomeEventHandler
+{
+    
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.InvalidStartStopTimestamp)
+                .WithSpan(5, 2, 5, 131)
+                .WithArguments("startFromTimestamp","stopAtTimestamp"),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+    
+    [Fact]
+    public async Task ShouldDetectDetectMissingEventTypeAnnotation()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"")]
+class SomeEventHandler
+{
+    public void Handle(SomeEvent evt, EventContext context)
+    {
+    }
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.Events.MissingAttribute)
+                .WithSpan(10, 34, 10, 37)
+                .WithArguments("SomeEvent"),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+    
+    [Fact]
+    public async Task ShouldDetectInvalidAccessibilityWhenNotSpecific()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp:""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    void Handle(SomeEvent evt, EventContext context)
+    {
+    }
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.InvalidAccessibility)
+                .WithSpan(11, 10, 11, 16)
+                .WithArguments("Handle", "Public"),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+    
+    [Fact]
+    public async Task ShouldDetectInvalidAccessibilityWhenPrivate()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp:""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    private void Handle(SomeEvent evt, EventContext context)
+    {
+    }
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.InvalidAccessibility)
+                .WithSpan(11, 18, 11, 24)
+                .WithArguments("Handle", "Public"),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ShouldDetectInvalidAccessibilityWhenInternal()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp:""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    internal void Handle(SomeEvent evt, EventContext context)
+    {
+    }
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.InvalidAccessibility)
+                .WithSpan(11, 19, 11, 25)
+                .WithArguments("Handle", "Public"),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+    
+    [Fact]
+    public async Task ShouldDetectMissingEventContext()
+    {
+        var test = @"
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Events.Handling;
+
+[EventType(""86dd35ee-cd28-48d9-a0cd-cb2aa11851aa"")]
+record SomeEvent();
+
+[EventHandler(""86dd35ee-cd28-48d9-a0cd-cb2aa11851af"", startFrom: ProcessFrom.Latest, stopAtTimestamp:""2023-09-15T07:30Z"")]
+class SomeEventHandler
+{
+    public void Handle(SomeEvent evt)
+    {
+    }
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.Events.MissingEventContext)
+                .WithSpan(11, 17, 11, 23)
+                .WithArguments("Handle"),
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+    
+}


### PR DESCRIPTION
## Summary

Adds support for new features from runtime V9.1. This includes the ability to configure event handlers to start from the latest events instead of the beginning (startFrom), as well as being able to limit the handler to events produced within a specific timeframe. (startFromTimestamp, stopAtTimestamp)

In addition this release comes with new analyzers for event handlers, making sure that incorrect use of the handlers should be a compile time issue instead of a runtime one. 

### Added

- EventHandlerAttribute: startFrom (Earliest / Latest)
- EventHandlerAttribute: startFromTimestamp - Overrides startFrom if set, ensures the handlers starts on the first event after the given timestamp. It can be in the future.
- EventHandlerAttribute: stopAtTimestamp - If set, the event handler will stop processing when it reaches events newer than this timestamp.
- Additional Roslyn analyzers, to ensure correct use of EventHandlers / aggregates