### PR TITLE
Maintenance release

### DIFF
--- a/Samples/DependencyInjection/DependencyInjection.csproj
+++ b/Samples/DependencyInjection/DependencyInjection.csproj
@@ -9,6 +9,11 @@
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
         <PackageReference Include="Lamar" Version="8.0.1" />
         <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Source/Diagnostics.OpenTelemetry/Diagnostics.OpenTelemetry.csproj
+++ b/Source/Diagnostics.OpenTelemetry/Diagnostics.OpenTelemetry.csproj
@@ -12,12 +12,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.0-beta.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
         <PackageReference Include="Proto.OpenTelemetry" Version="$(ProtoActorVersion)" />
         <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="$(MongoDBOpenTelemetryVersion)" />
     </ItemGroup>

--- a/Source/Events/Events.csproj
+++ b/Source/Events/Events.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftVersion)" />
-        <PackageReference Include="System.Collections.Immutable" Version="$(SystemImmutableVersion)" />
+        <PackageReference Include="System.Collections.Immutable" Version="$(MicrosoftExtensionsVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -6,14 +6,14 @@
         <ContractsVersion>7.8.0</ContractsVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
-        <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>
+        <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
         <MicrosoftDotNetTestVersion>17.7.2</MicrosoftDotNetTestVersion>
-        <ProtoActorVersion>1.5.0</ProtoActorVersion>
+        <ProtoActorVersion>1.6.0</ProtoActorVersion>
         <RxVersion>4.4.1</RxVersion>
-        <ProtobufVersion>3.24.4</ProtobufVersion>
-        <GrpcVersion>2.58.0</GrpcVersion>
-        <MongoDBDriverVersion>2.22.0</MongoDBDriverVersion>
-        <OpenTelemetryVersion>1.6.0</OpenTelemetryVersion>
+        <ProtobufVersion>3.25.3</ProtobufVersion>
+        <GrpcVersion>2.61.0</GrpcVersion>
+        <MongoDBDriverVersion>2.24.0</MongoDBDriverVersion>
+        <OpenTelemetryVersion>1.7.0</OpenTelemetryVersion>
         <MongoDBOpenTelemetryVersion>1.0.0</MongoDBOpenTelemetryVersion>
         <NewtonsoftVersion>13.0.3</NewtonsoftVersion>
         <SystemImmutableVersion>7.0.0</SystemImmutableVersion>


### PR DESCRIPTION
## Summary
Maintenance release - Updated library dependencies

### Changed

- Updated OTEL to 1.7
- Updated Proto.Actor to 1.6
- Updated Microsoft extensions to 8.0
- Updated Mongo drivers to 2.24
- Updated Grpc & Protobuf to latest