### PR TITLE
[DRAFT] Enable Using Return Types From Aggregates Methods

### DIFF
--- a/Source/Aggregates/IAggregateRootOperations.cs
+++ b/Source/Aggregates/IAggregateRootOperations.cs
@@ -29,5 +29,5 @@ public interface IAggregateRootOperations<TAggregate>
     /// <param name="method"><see cref="Action{T}">Method</see> to perform.</param>
     /// <param name="cancellationToken">Token that can be used to cancel this operation.</param>
     /// <returns>The <see cref="Task" /> representing the asynchronous operation.</returns>
-    Task Perform(Func<TAggregate, Task> method, CancellationToken cancellationToken = default);
+    Task<object> Perform(Func<TAggregate, Task<object>> method, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary

As a SDK user I would like to have a possibility of using Aggregates' methods in order to obtain information - this PR aims to start work on it. The design was done pretty quickly, and as a result of that is quite ugly, so just treat it as a starter, it probably can be done way better. 

### Added

- Return type from Perform Method in the AggregateRootOperations

### Removed

- Perform Method in the AggregateRootOperations, which takes Func<TAggregate, Task> as an input


