### PR TITLE
Time-keyed projections

### DIFF
--- a/Source/Projections/Builder/KeySelectorBuilder.cs
+++ b/Source/Projections/Builder/KeySelectorBuilder.cs
@@ -14,13 +14,13 @@ public class KeySelectorBuilder
     /// Select projection key from the <see cref="EventSourceId"/>.
     /// </summary>
     /// <returns>A <see cref="KeySelector"/>.</returns>
-    public static KeySelector KeyFromEventSource() => KeySelector.EventSource;
+    public static KeySelector KeyFromEventSource => KeySelector.EventSource;
 
     /// <summary>
     /// Select projection key from the <see cref="PartitionId"/>.
     /// </summary>
     /// <returns>A <see cref="KeySelector"/>.</returns>
-    public static KeySelector KeyFromPartitionId() => KeySelector.Partition;
+    public static KeySelector KeyFromPartitionId => KeySelector.Partition;
 
     /// <summary>
     /// Select projection key from a property of the event.
@@ -46,4 +46,21 @@ public class KeySelectorBuilder
     /// <returns>A <see cref="KeySelector"/>.</returns>
     public static KeySelector KeyFromEventOccurred(OccurredFormat occurredFormat)
         => KeySelector.Occurred(occurredFormat);
+    
+    /// <summary>
+    /// Select projection key from a property of the event.
+    /// </summary>
+    /// <param name="selectorExpression">The property on the event.</param>
+    /// <param name="occurredFormat">The date time format.</param>
+    /// <returns>A <see cref="KeySelector"/>.</returns>
+    public static KeySelector KeyFromPropertyAndEventOccurred(KeySelectorExpression selectorExpression, OccurredFormat occurredFormat)
+        => KeySelector.PropertyAndOccured(selectorExpression, occurredFormat);
+    
+    /// <summary>
+    /// Select projection key from when an event occurred.
+    /// </summary>
+    /// <param name="occurredFormat">The date time format.</param>
+    /// <returns>A <see cref="KeySelector"/>.</returns>
+    public static KeySelector KeyFromEventSourceIdAndOccurred(OccurredFormat occurredFormat)
+        => KeySelector.EventSourceAndOccured(occurredFormat);
 }

--- a/Source/Projections/Builder/KeySelectorBuilder{TEvent}.cs
+++ b/Source/Projections/Builder/KeySelectorBuilder{TEvent}.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Dolittle.SDK.Events;
 
 namespace Dolittle.SDK.Projections.Builder;
 
@@ -28,5 +29,19 @@ public class KeySelectorBuilder<TEvent> : KeySelectorBuilder
         }
 
         throw new KeySelectorExpressionWasNotAMemberExpression();
+    }
+
+    /// <summary>
+    /// Select projection key from a property of the event.
+    /// </summary>
+    /// <typeparam name="TProperty">The property type.</typeparam>
+    /// <param name="function">The function for getting the projection key (id).</param>
+    /// <returns>A <see cref="KeySelector"/>.</returns>
+    /// <exception cref="KeySelectorExpressionWasNotAMemberExpression">Is thrown when the provided property expression is not a member expression.</exception>
+    public KeySelector KeyFromFunction(Func<TEvent, EventContext, Key> function)
+    {
+        if (function is null) throw new ArgumentNullException(nameof(function));
+
+        return KeySelector.ByFunction(function);
     }
 }

--- a/Source/Projections/IKeySelector.cs
+++ b/Source/Projections/IKeySelector.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.SDK.Events;
+
+namespace Dolittle.SDK.Projections;
+
+/// <summary>
+/// Use this interface to define projection key selectors.
+/// Instances of this interface MUST be thread safe and stateless, as they are used as singletons.
+/// </summary>
+/// <typeparam name="TEvent">The mapped event type</typeparam>
+public interface IKeySelector<TEvent> where TEvent : class
+{
+    /// <summary>
+    /// Map to a <see cref="Key"/> from an event and context.
+    /// </summary>
+    /// <param name="event"></param>
+    /// <param name="eventContext"></param>
+    /// <returns>The projection key</returns>
+    Key Selector(TEvent @event, EventContext eventContext);
+}

--- a/Source/Projections/Internal/ProjectionsProcessor.cs
+++ b/Source/Projections/Internal/ProjectionsProcessor.cs
@@ -103,28 +103,4 @@ public class ProjectionsProcessor<TReadModel> : EventProcessor<ProjectionId, Eve
     /// <inheritdoc/>
     protected override EventHandlerResponse CreateResponseFromFailure(ProcessorFailure failure)
         => new() { Failure = failure };
-
-    // static ProjectionEventSelector CreateProjectionEventSelector(EventSelector eventSelector)
-    // {
-    //     static ProjectionEventSelector WithEventType(EventSelector eventSelector, Action<ProjectionEventSelector> callback)
-    //     {
-    //         var message = new ProjectionEventSelector();
-    //         callback(message);
-    //         message.EventType = eventSelector.EventType.ToProtobuf();
-    //         return message;
-    //     }
-    //
-    //     return eventSelector.KeySelector.Type switch
-    //     {
-    //         KeySelectorType.EventSourceId => WithEventType(eventSelector, _ => _.EventSourceKeySelector = new EventSourceIdKeySelector()),
-    //         KeySelectorType.PartitionId => WithEventType(eventSelector, _ => _.PartitionKeySelector = new PartitionIdKeySelector()),
-    //         KeySelectorType.Property => WithEventType(eventSelector,
-    //             _ => _.EventPropertyKeySelector = new EventPropertyKeySelector { PropertyName = eventSelector.KeySelector.Expression ?? string.Empty }),
-    //         KeySelectorType.Static => WithEventType(eventSelector,
-    //             _ => _.StaticKeySelector = new StaticKeySelector { StaticKey = eventSelector.KeySelector.StaticKey ?? string.Empty }),
-    //         KeySelectorType.EventOccurred => WithEventType(eventSelector,
-    //             _ => _.EventOccurredKeySelector = new EventOccurredKeySelector { Format = eventSelector.KeySelector.OccurredFormat ?? string.Empty }),
-    //         _ => throw new UnknownKeySelectorType(eventSelector.KeySelector.Type)
-    //     };
-    // }
 }

--- a/Source/Projections/Internal/ProjectionsProcessor.cs
+++ b/Source/Projections/Internal/ProjectionsProcessor.cs
@@ -104,27 +104,27 @@ public class ProjectionsProcessor<TReadModel> : EventProcessor<ProjectionId, Eve
     protected override EventHandlerResponse CreateResponseFromFailure(ProcessorFailure failure)
         => new() { Failure = failure };
 
-    static ProjectionEventSelector CreateProjectionEventSelector(EventSelector eventSelector)
-    {
-        static ProjectionEventSelector WithEventType(EventSelector eventSelector, Action<ProjectionEventSelector> callback)
-        {
-            var message = new ProjectionEventSelector();
-            callback(message);
-            message.EventType = eventSelector.EventType.ToProtobuf();
-            return message;
-        }
-
-        return eventSelector.KeySelector.Type switch
-        {
-            KeySelectorType.EventSourceId => WithEventType(eventSelector, _ => _.EventSourceKeySelector = new EventSourceIdKeySelector()),
-            KeySelectorType.PartitionId => WithEventType(eventSelector, _ => _.PartitionKeySelector = new PartitionIdKeySelector()),
-            KeySelectorType.Property => WithEventType(eventSelector,
-                _ => _.EventPropertyKeySelector = new EventPropertyKeySelector { PropertyName = eventSelector.KeySelector.Expression ?? string.Empty }),
-            KeySelectorType.Static => WithEventType(eventSelector,
-                _ => _.StaticKeySelector = new StaticKeySelector { StaticKey = eventSelector.KeySelector.StaticKey ?? string.Empty }),
-            KeySelectorType.EventOccurred => WithEventType(eventSelector,
-                _ => _.EventOccurredKeySelector = new EventOccurredKeySelector { Format = eventSelector.KeySelector.OccurredFormat ?? string.Empty }),
-            _ => throw new UnknownKeySelectorType(eventSelector.KeySelector.Type)
-        };
-    }
+    // static ProjectionEventSelector CreateProjectionEventSelector(EventSelector eventSelector)
+    // {
+    //     static ProjectionEventSelector WithEventType(EventSelector eventSelector, Action<ProjectionEventSelector> callback)
+    //     {
+    //         var message = new ProjectionEventSelector();
+    //         callback(message);
+    //         message.EventType = eventSelector.EventType.ToProtobuf();
+    //         return message;
+    //     }
+    //
+    //     return eventSelector.KeySelector.Type switch
+    //     {
+    //         KeySelectorType.EventSourceId => WithEventType(eventSelector, _ => _.EventSourceKeySelector = new EventSourceIdKeySelector()),
+    //         KeySelectorType.PartitionId => WithEventType(eventSelector, _ => _.PartitionKeySelector = new PartitionIdKeySelector()),
+    //         KeySelectorType.Property => WithEventType(eventSelector,
+    //             _ => _.EventPropertyKeySelector = new EventPropertyKeySelector { PropertyName = eventSelector.KeySelector.Expression ?? string.Empty }),
+    //         KeySelectorType.Static => WithEventType(eventSelector,
+    //             _ => _.StaticKeySelector = new StaticKeySelector { StaticKey = eventSelector.KeySelector.StaticKey ?? string.Empty }),
+    //         KeySelectorType.EventOccurred => WithEventType(eventSelector,
+    //             _ => _.EventOccurredKeySelector = new EventOccurredKeySelector { Format = eventSelector.KeySelector.OccurredFormat ?? string.Empty }),
+    //         _ => throw new UnknownKeySelectorType(eventSelector.KeySelector.Type)
+    //     };
+    // }
 }

--- a/Source/Projections/KeyFromEventOccurredAttribute.cs
+++ b/Source/Projections/KeyFromEventOccurredAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Dolittle.SDK.Projections.Builder;
 
 namespace Dolittle.SDK.Projections;
 

--- a/Source/Projections/KeyFromEventSourceAndOccurredAttribute.cs
+++ b/Source/Projections/KeyFromEventSourceAndOccurredAttribute.cs
@@ -12,7 +12,7 @@ namespace Dolittle.SDK.Projections;
 public class KeyFromEventSourceAndOccurredAttribute : Attribute, IKeySelectorAttribute
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="KeyFromPropertyAttribute"/> class.
+    /// Initializes a new instance of the <see cref="KeyFromEventSourceAndOccurredAttribute"/> class.
     /// </summary>
     /// <param name="propertyName">The name of the property.</param>
     /// <param name="occurredFormat">The date time format.</param>

--- a/Source/Projections/KeyFromEventSourceAndOccurredAttribute.cs
+++ b/Source/Projections/KeyFromEventSourceAndOccurredAttribute.cs
@@ -7,16 +7,20 @@ using Dolittle.SDK.Projections.Builder;
 namespace Dolittle.SDK.Projections;
 
 /// <summary>
-/// Decorates a projection method with the <see cref="KeySelectorType.EventOccurred" />.
+/// Decorates a projection method with the <see cref="KeySelectorType.Property" />.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-public class KeyFromEventOccurredAttribute : Attribute, IKeySelectorAttribute
+public class KeyFromEventSourceAndOccurredAttribute : Attribute, IKeySelectorAttribute
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="KeyFromEventOccurredAttribute"/> class.
+    /// Initializes a new instance of the <see cref="KeyFromPropertyAttribute"/> class.
     /// </summary>
+    /// <param name="propertyName">The name of the property.</param>
     /// <param name="occurredFormat">The date time format.</param>
-    public KeyFromEventOccurredAttribute(string occurredFormat) => OccurredFormat = occurredFormat;
+    public KeyFromEventSourceAndOccurredAttribute(string occurredFormat)
+    {
+        OccurredFormat = occurredFormat;
+    }
 
     /// <summary>
     /// Gets the <see cref="OccurredFormat" />.
@@ -24,5 +28,5 @@ public class KeyFromEventOccurredAttribute : Attribute, IKeySelectorAttribute
     public OccurredFormat OccurredFormat { get; }
 
     /// <inheritdoc/>
-    public KeySelector KeySelector => KeySelector.Occurred(OccurredFormat);
+    public KeySelector KeySelector => KeySelector.EventSourceAndOccured(OccurredFormat);
 }

--- a/Source/Projections/KeyFromEventSourceAndOccurredAttribute.cs
+++ b/Source/Projections/KeyFromEventSourceAndOccurredAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Dolittle.SDK.Projections.Builder;
 
 namespace Dolittle.SDK.Projections;
 

--- a/Source/Projections/KeyFromEventSourceAttribute.cs
+++ b/Source/Projections/KeyFromEventSourceAttribute.cs
@@ -13,5 +13,5 @@ namespace Dolittle.SDK.Projections;
 public class KeyFromEventSourceAttribute : Attribute, IKeySelectorAttribute
 {
     /// <inheritdoc/>
-    public KeySelector KeySelector { get; } = KeySelectorBuilder.KeyFromEventSource();
+    public KeySelector KeySelector => KeySelector.EventSource;
 }

--- a/Source/Projections/KeyFromEventSourceAttribute.cs
+++ b/Source/Projections/KeyFromEventSourceAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Dolittle.SDK.Projections.Builder;
 
 namespace Dolittle.SDK.Projections;
 

--- a/Source/Projections/KeyFromFunctionAttribute.cs
+++ b/Source/Projections/KeyFromFunctionAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dolittle.SDK.Projections;
+
+static class KeySelectorInstance<TKeySelector, TEvent> where TKeySelector : IKeySelector<TEvent>, new() where TEvent : class
+{
+    public static TKeySelector Mapper { get; } = new();
+    public static KeySelector Instance { get; } = KeySelector.ByFunction<TEvent>(Mapper.Selector);
+}
+
+/// <summary>
+/// Decorates a projection method with the <see cref="KeySelectorType.Function" />.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class KeyFromFunctionAttribute<TKeySelector, TEvent> : Attribute, IKeySelectorAttribute
+    where TKeySelector : IKeySelector<TEvent>, new() where TEvent : class
+{
+    /// <inheritdoc/>
+    public KeySelector KeySelector => KeySelectorInstance<TKeySelector, TEvent>.Instance;
+}

--- a/Source/Projections/KeyFromPartitionAttribute.cs
+++ b/Source/Projections/KeyFromPartitionAttribute.cs
@@ -13,5 +13,5 @@ namespace Dolittle.SDK.Projections;
 public class KeyFromPartitionAttribute : Attribute, IKeySelectorAttribute
 {
     /// <inheritdoc/>
-    public KeySelector KeySelector { get; } = KeySelectorBuilder.KeyFromPartitionId();
+    public KeySelector KeySelector => KeySelector.Partition;
 }

--- a/Source/Projections/KeyFromPartitionAttribute.cs
+++ b/Source/Projections/KeyFromPartitionAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Dolittle.SDK.Projections.Builder;
 
 namespace Dolittle.SDK.Projections;
 

--- a/Source/Projections/KeyFromPropertyAndOccurredAttribute.cs
+++ b/Source/Projections/KeyFromPropertyAndOccurredAttribute.cs
@@ -10,19 +10,30 @@ namespace Dolittle.SDK.Projections;
 /// Decorates a projection method with the <see cref="KeySelectorType.Property" />.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-public class KeyFromPropertyAttribute : Attribute, IKeySelectorAttribute
+public class KeyFromPropertyAndOccurredAttribute : Attribute, IKeySelectorAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="KeyFromPropertyAttribute"/> class.
     /// </summary>
     /// <param name="propertyName">The name of the property.</param>
-    public KeyFromPropertyAttribute(string propertyName) => Expression = propertyName;
+    /// <param name="occurredFormat">The date time format.</param>
+    public KeyFromPropertyAndOccurredAttribute(string propertyName, string occurredFormat)
+    {
+        Expression = propertyName;
+        OccurredFormat = occurredFormat;
+    }
+
 
     /// <summary>
     /// Gets the <see cref="KeySelector" />.
     /// </summary>
     public KeySelectorExpression Expression { get; }
 
+    /// <summary>
+    /// Gets the <see cref="OccurredFormat" />.
+    /// </summary>
+    public OccurredFormat OccurredFormat { get; }
+
     /// <inheritdoc/>
-    public KeySelector KeySelector => KeySelector.Property(Expression);
+    public KeySelector KeySelector => KeySelector.PropertyAndOccured(Expression, OccurredFormat);
 }

--- a/Source/Projections/KeyFromPropertyAndOccurredAttribute.cs
+++ b/Source/Projections/KeyFromPropertyAndOccurredAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Dolittle.SDK.Projections.Builder;
 
 namespace Dolittle.SDK.Projections;
 
@@ -22,7 +21,6 @@ public class KeyFromPropertyAndOccurredAttribute : Attribute, IKeySelectorAttrib
         Expression = propertyName;
         OccurredFormat = occurredFormat;
     }
-
 
     /// <summary>
     /// Gets the <see cref="KeySelector" />.

--- a/Source/Projections/KeyFromPropertyAttribute.cs
+++ b/Source/Projections/KeyFromPropertyAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Dolittle.SDK.Projections.Builder;
 
 namespace Dolittle.SDK.Projections;
 

--- a/Source/Projections/KeySelectorType.cs
+++ b/Source/Projections/KeySelectorType.cs
@@ -29,7 +29,22 @@ public enum KeySelectorType
     Static,
     
     /// <summary>
-    /// Gets the key the event occurred metadata.
+    /// Gets the key from the event occurred metadata.
     /// </summary>
     EventOccurred,
+    
+    /// <summary>
+    /// Gets the key from a named property on the event content and the event occurred metadata.
+    /// </summary>
+    PropertyAndEventOccurred,
+    
+    /// <summary>
+    /// Gets the key Gets the key from the event source id and the event occurred metadata.
+    /// </summary>
+    EventSourceIdAndOccurred,
+    
+    /// <summary>
+    /// The key is returned as a function of the event and the event context.
+    /// </summary>
+    Function
 }

--- a/Source/Projections/StaticKeyAttribute.cs
+++ b/Source/Projections/StaticKeyAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Dolittle.SDK.Projections.Builder;
 
 namespace Dolittle.SDK.Projections;
 

--- a/Source/Projections/StaticKeyAttribute.cs
+++ b/Source/Projections/StaticKeyAttribute.cs
@@ -24,5 +24,5 @@ public class StaticKeyAttribute : Attribute, IKeySelectorAttribute
     public Key StaticKey { get; }
 
     /// <inheritdoc/>
-    public KeySelector KeySelector => KeySelectorBuilder.StaticKey(StaticKey);
+    public KeySelector KeySelector => KeySelector.Static(StaticKey);
 }

--- a/Tests/ProjectionsTests/KeyFromEventSourceAndOccurredTests.cs
+++ b/Tests/ProjectionsTests/KeyFromEventSourceAndOccurredTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Dolittle.SDK.Projections.Occurred;
+using Dolittle.SDK.Testing.Projections;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Dolittle.SDK.Projections;
+
+public class KeyFromEventSourceAndOccurredTests : ProjectionTests<SalesPerDayTotalByEventSource>
+{
+    [Fact]
+    public void ShouldAggregateByDayAndStore()
+    {
+        WithEvent("store1", new ProductSold("store1", "product1", 10, 100),
+            DateTimeOffset.Parse("2024-01-01", NumberFormatInfo.InvariantInfo));
+        WithEvent("store1", new ProductSold("store1", "product2", 10, 100),
+            DateTimeOffset.Parse("2024-01-01", NumberFormatInfo.InvariantInfo));
+        WithEvent("store1", new ProductSold("store1", "product1", 10, 10), DateTimeOffset.Parse("2024-01-02", NumberFormatInfo.InvariantInfo));
+        WithEvent("store2", new ProductSold("store2", "product1", 5, 10), DateTimeOffset.Parse("2024-01-01", NumberFormatInfo.InvariantInfo));
+
+        using var _ = new AssertionScope();
+        
+        AssertThat.HasReadModel("store1_2024-01-01").Where(
+            it => it.TotalSales.Should().Be(2000),
+            it => it.Store.Should().Be("store1"),
+            it => it.Date.Should().Be(new DateOnly(2024, 1, 1))
+        );
+        
+        AssertThat.HasReadModel("store1_2024-01-02").Where(
+            it => it.TotalSales.Should().Be(100),
+            it => it.Store.Should().Be("store1"),
+            it => it.Date.Should().Be(new DateOnly(2024, 1, 2))
+        );
+        
+        AssertThat.HasReadModel("store2_2024-01-01").Where(
+            it => it.TotalSales.Should().Be(50),
+            it => it.Store.Should().Be("store2"),
+            it => it.Date.Should().Be(new DateOnly(2024, 1, 1))
+        );
+    }
+}

--- a/Tests/ProjectionsTests/KeyFromFunctionTests.cs
+++ b/Tests/ProjectionsTests/KeyFromFunctionTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Dolittle.SDK.Projections.Occurred;
+using Dolittle.SDK.Testing.Projections;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Dolittle.SDK.Projections;
+
+public class KeyFromFunctionTests : ProjectionTests<SalesPerDayTotalByFunction>
+{
+    [Fact]
+    public void ShouldAggregateByDayAndStore()
+    {
+        WithEvent(Guid.NewGuid().ToString(), new ProductSold("store1", "product1", 10, 100),
+            DateTimeOffset.Parse("2024-01-01", NumberFormatInfo.InvariantInfo));
+        WithEvent(Guid.NewGuid().ToString(), new ProductSold("store1", "product2", 10, 100),
+            DateTimeOffset.Parse("2024-01-01", NumberFormatInfo.InvariantInfo));
+        WithEvent(Guid.NewGuid().ToString(), new ProductSold("store1", "product1", 10, 10), DateTimeOffset.Parse("2024-01-02", NumberFormatInfo.InvariantInfo));
+        WithEvent(Guid.NewGuid().ToString(), new ProductSold("store2", "product1", 5, 10), DateTimeOffset.Parse("2024-01-01", NumberFormatInfo.InvariantInfo));
+
+        using var _ = new AssertionScope();
+        
+        AssertThat.HasReadModel("store1_2024-01-01").Where(
+            it => it.TotalSales.Should().Be(2000),
+            it => it.Store.Should().Be("store1"),
+            it => it.Date.Should().Be(new DateOnly(2024, 1, 1))
+        );
+        
+        AssertThat.HasReadModel("store1_2024-01-02").Where(
+            it => it.TotalSales.Should().Be(100),
+            it => it.Store.Should().Be("store1"),
+            it => it.Date.Should().Be(new DateOnly(2024, 1, 2))
+        );
+        
+        AssertThat.HasReadModel("store2_2024-01-01").Where(
+            it => it.TotalSales.Should().Be(50),
+            it => it.Store.Should().Be("store2"),
+            it => it.Date.Should().Be(new DateOnly(2024, 1, 1))
+        );
+    }
+}

--- a/Tests/ProjectionsTests/KeyFromPropertyAndOccurredTests.cs
+++ b/Tests/ProjectionsTests/KeyFromPropertyAndOccurredTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Dolittle.SDK.Projections.Occurred;
+using Dolittle.SDK.Testing.Projections;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Dolittle.SDK.Projections;
+
+public class KeyFromPropertyAndOccurredTests : ProjectionTests<SalesPerDayByStoreProperty>
+{
+    [Fact]
+    public void ShouldAggregateByDayAndStore()
+    {
+        WithEvent(Guid.NewGuid().ToString(), new ProductSold("store1", "product1", 10, 100),
+            DateTimeOffset.Parse("2024-01-01", NumberFormatInfo.InvariantInfo));
+        WithEvent(Guid.NewGuid().ToString(), new ProductSold("store1", "product2", 10, 100),
+            DateTimeOffset.Parse("2024-01-01", NumberFormatInfo.InvariantInfo));
+        WithEvent(Guid.NewGuid().ToString(), new ProductSold("store1", "product1", 10, 10), DateTimeOffset.Parse("2024-01-02", NumberFormatInfo.InvariantInfo));
+        WithEvent(Guid.NewGuid().ToString(), new ProductSold("store2", "product1", 5, 10), DateTimeOffset.Parse("2024-01-01", NumberFormatInfo.InvariantInfo));
+
+        using var _ = new AssertionScope();
+        
+        AssertThat.HasReadModel("store1_2024-01-01").Where(
+            it => it.TotalSales.Should().Be(2000),
+            it => it.Store.Should().Be("store1"),
+            it => it.Date.Should().Be(new DateOnly(2024, 1, 1))
+        );
+        
+        AssertThat.HasReadModel("store1_2024-01-02").Where(
+            it => it.TotalSales.Should().Be(100),
+            it => it.Store.Should().Be("store1"),
+            it => it.Date.Should().Be(new DateOnly(2024, 1, 2))
+        );
+        
+        AssertThat.HasReadModel("store2_2024-01-01").Where(
+            it => it.TotalSales.Should().Be(50),
+            it => it.Store.Should().Be("store2"),
+            it => it.Date.Should().Be(new DateOnly(2024, 1, 1))
+        );
+    }
+}

--- a/Tests/ProjectionsTests/Occurred/SalesPerDay.cs
+++ b/Tests/ProjectionsTests/Occurred/SalesPerDay.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.SDK.Events;
+
+namespace Dolittle.SDK.Projections.Occurred;
+
+[EventType("37c19042-3ac8-4ec0-8de1-9ecb4b8c56b0")]
+public record ProductSold(string Store, string Product, decimal Quantity, decimal Price);
+
+[Projection("3dce944f-279e-4150-bef3-dd9e113220c6")]
+public class SalesPerDayByStoreProperty : ReadModel
+{
+    public string Store { get; private set; }
+    public DateOnly Date { get; private set; }
+
+    public decimal TotalSales { get; private set; }
+
+    [KeyFromPropertyAndOccurred(nameof(ProductSold.Store), "yyyy-MM-dd")]
+    public void On(ProductSold evt, EventContext ctx)
+    {
+        if (string.IsNullOrEmpty(Store))
+        {
+            Store = evt.Store;
+            Date = new DateOnly(ctx.Occurred.Year, ctx.Occurred.Month, ctx.Occurred.Day);
+        }
+
+        TotalSales += evt.Quantity * evt.Price;
+    }
+}
+
+[Projection("3dce944f-279e-4150-bef3-dd9e113220c6")]
+public class SalesPerDayTotalByEventSource : ReadModel
+{
+    public string Store { get; private set; }
+    public DateOnly Date { get; private set; }
+
+    public decimal TotalSales { get; private set; }
+
+    [KeyFromEventSourceAndOccurred("yyyy-MM-dd")]
+    public void On(ProductSold evt, EventContext ctx)
+    {
+        if (string.IsNullOrEmpty(Store))
+        {
+            Store = evt.Store;
+            Date = new DateOnly(ctx.Occurred.Year, ctx.Occurred.Month, ctx.Occurred.Day);
+        }
+
+        TotalSales += evt.Quantity * evt.Price;
+    }
+}


### PR DESCRIPTION
## Summary
Added the ability to use projections keyed both on event properties, eventSourceId and when the event occurred.

This enables projections to be used for aggregations over time, and to optimize read  model for specific statistics.

In addition there has been added the ability to key by function, which gives complete control over which id to target

### Added
- `KeyFromPropertyAndOccurredAttribute`
- `KeyFromEventSourceAndOccurredAttribute`
- `KeyFromFunctionAttribute`
