### PR TITLE
Projections improvements / maintenance

### DIFF
--- a/Samples/ASP.NET/Customers/CustomersController.cs
+++ b/Samples/ASP.NET/Customers/CustomersController.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Dolittle.SDK.Projections.Store;
 using Microsoft.AspNetCore.Mvc;
@@ -27,4 +29,15 @@ public class CustomerController : ControllerBase
 
         return state?.Dishes ?? Array.Empty<string>();
     }
+    
+    [HttpGet("All")]
+    public async Task<List<DishesEaten>> GetDishesEaten()
+    {
+        var states = _dishesEaten
+            .Query()
+            .ToList();
+
+        return states;
+    }
+    
 }

--- a/Samples/ASP.NET/Customers/DishesEaten.cs
+++ b/Samples/ASP.NET/Customers/DishesEaten.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
+using Dolittle.SDK.Events;
 using Dolittle.SDK.Projections;
 
 namespace Customers;
@@ -10,7 +11,7 @@ namespace Customers;
 public class DishesEaten: ReadModel
 {
     public string[] Dishes { get; set; } = {};
-    
+
     public void On(DishEaten evt, ProjectionContext ctx)
     {
         Dishes = Dishes.Append(evt.Dish).ToArray();

--- a/Source/Diagnostics.OpenTelemetry/Diagnostics.OpenTelemetry.csproj
+++ b/Source/Diagnostics.OpenTelemetry/Diagnostics.OpenTelemetry.csproj
@@ -16,8 +16,8 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
         <PackageReference Include="Proto.OpenTelemetry" Version="$(ProtoActorVersion)" />
         <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="$(MongoDBOpenTelemetryVersion)" />
     </ItemGroup>

--- a/Source/Diagnostics.OpenTelemetry/Diagnostics.OpenTelemetry.csproj
+++ b/Source/Diagnostics.OpenTelemetry/Diagnostics.OpenTelemetry.csproj
@@ -22,4 +22,8 @@
         <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="$(MongoDBOpenTelemetryVersion)" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Actors\" />
+    </ItemGroup>
+
 </Project>

--- a/Source/Events/Store/Converters/JsonSerializerExceptionCatcher.cs
+++ b/Source/Events/Store/Converters/JsonSerializerExceptionCatcher.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -15,6 +16,7 @@ public class JsonSerializerExceptionCatcher
     /// <summary>
     /// Gets a value indicating whether the serializer operation failed or not.
     /// </summary>
+    [MemberNotNullWhen(true, nameof(Error))]
     public bool Failed { get; private set; }
 
     /// <summary>

--- a/Source/Projections/Internal/Log.cs
+++ b/Source/Projections/Internal/Log.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Events.Store;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.SDK.Projections.Internal;
+
+/// <summary>
+/// Log messages for <see cref="Dolittle.SDK.Projections.Store"/>.
+/// </summary>
+static partial class Log
+{
+    [LoggerMessage(0, LogLevel.Error, "Error processing projection for {@CommittedEvent} ")]
+    internal static partial void ErrorProcessingProjectionEvent(this ILogger logger, Exception e, CommittedEvent committedEvent);
+}

--- a/Source/Projections/Internal/ProjectionsProcessor.cs
+++ b/Source/Projections/Internal/ProjectionsProcessor.cs
@@ -90,7 +90,7 @@ public class ProjectionsProcessor<TReadModel> : EventProcessor<ProjectionId, Eve
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Error processing projection event {Event} for ", committedEvent);
+            _logger.ErrorProcessingProjectionEvent(e, committedEvent);
             activity?.RecordException(e);
             throw;
         }

--- a/Source/Projections/Projections.csproj
+++ b/Source/Projections/Projections.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Proto.Cluster" Version="$(ProtoActorVersion)" />
+        <PackageReference Include="Proto.OpenTelemetry" Version="$(ProtoActorVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
     </ItemGroup>

--- a/Source/Projections/Store/ProjectionOf.cs
+++ b/Source/Projections/Store/ProjectionOf.cs
@@ -52,6 +52,7 @@ public class ProjectionOf<TReadModel> : IProjectionOf<TReadModel>
     /// <inheritdoc />
     public ScopeId Scope { get; }
 
+    /// <inheritdoc />
     public Task<TReadModel?> Get(Key key, CancellationToken cancellation = default)
     {
         return Get(key.Value, cancellation);
@@ -68,6 +69,7 @@ public class ProjectionOf<TReadModel> : IProjectionOf<TReadModel>
         return _collection.Find(it => it.Id.Equals(id)).FirstOrDefaultAsync(cancellationToken: cancellation)!;
     }
 
+    /// <inheritdoc />
     public ISubscription<TP?> Subscribe<TP>(string id, CancellationToken cancellationToken) where TP : TReadModel, ICloneable
         => _projectionClient.Subscribe<TP>(id, cancellationToken);
 

--- a/Source/SDK/Proto/ServiceCollectionExtensions.cs
+++ b/Source/SDK/Proto/ServiceCollectionExtensions.cs
@@ -87,8 +87,12 @@ static class ServiceCollectionExtensions
             return system;
         });
 
+
+
         self.AddSingleton(p => p.GetRequiredService<ActorSystem>().Cluster());
-        self.AddSingleton(p => p.GetRequiredService<ActorSystem>().Root.WithTracing());
+        self.AddSingleton(p =>
+            p.GetRequiredService<ActorSystem>()
+                .Root.WithSenderMiddleware(OpenTelemetryTracingExtensions.OpenTelemetrySenderMiddleware));
         self.AddHostedService(p =>
             new ProtoActorLifecycleHost(
                 p.GetRequiredService<ActorSystem>(),

--- a/specs.props
+++ b/specs.props
@@ -11,7 +11,7 @@
         <PackageReference Include="Machine.Specifications" Version="1.1.0" />
         <PackageReference Include="Machine.Specifications.Should" Version="1.0.0" />
         <PackageReference Include="moq" Version="4.18.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftDotNetTestVersion)" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="$(MachineSpecificationsRunnerVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
     </ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -7,13 +7,12 @@
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
-        <MicrosoftDotNetTestVersion>17.7.2</MicrosoftDotNetTestVersion>
         <ProtoActorVersion>1.6.0</ProtoActorVersion>
         <RxVersion>4.4.1</RxVersion>
-        <ProtobufVersion>3.25.3</ProtobufVersion>
-        <GrpcVersion>2.61.0</GrpcVersion>
+        <ProtobufVersion>3.26.1</ProtobufVersion>
+        <GrpcVersion>2.62.0</GrpcVersion>
         <MongoDBDriverVersion>2.24.0</MongoDBDriverVersion>
-        <OpenTelemetryVersion>1.7.0</OpenTelemetryVersion>
+        <OpenTelemetryVersion>1.8.1</OpenTelemetryVersion>
         <MongoDBOpenTelemetryVersion>1.0.0</MongoDBOpenTelemetryVersion>
         <NewtonsoftVersion>13.0.3</NewtonsoftVersion>
         <SystemImmutableVersion>7.0.0</SystemImmutableVersion>


### PR DESCRIPTION
## Summary
- Ensure proto.cluster messages wait for system readiness to begin processing. Previously it could start before Proto.Cluster had started, and logged errors. This did not affect the projection result itself, as the projection would be processed in a retry.
- Added projection tracing
- Updated OTEL & Grpc dependencies

Reduced OTEL resource usage:
- Skip send activity / span for Proto.Actor traces for root context.