### PR TITLE
Mutation Datetime analyzer / codefix

### DIFF
--- a/Benchmarks/SDK/SDK.csproj
+++ b/Benchmarks/SDK/SDK.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Source/Analyzers/AggregateAnalyzer.cs
+++ b/Source/Analyzers/AggregateAnalyzer.cs
@@ -87,7 +87,7 @@ public class AggregateAnalyzer : DiagnosticAnalyzer
                 context.ReportDiagnostic(Diagnostic.Create(DescriptorRules.Aggregate.MutationHasIncorrectNumberOfParameters, syntax.GetLocation(),
                     onMethod.ToDisplayString()));
             }
-            EnsureMutationDoesNotAccessCurrentTime(syntax, context);
+            EnsureMutationDoesNotAccessCurrentTime(context, syntax);
             
 
             if (parameters.Length > 0)
@@ -114,9 +114,9 @@ public class AggregateAnalyzer : DiagnosticAnalyzer
     /// Checks if the method gets the current time via DateTime or DateTimeOffset
     /// Since this is not allowed for the mutations, we need to report a diagnostic
     /// </summary>
-    /// <param name="onMethod"></param>
     /// <param name="context"></param>
-    static void EnsureMutationDoesNotAccessCurrentTime(MethodDeclarationSyntax onMethod, SyntaxNodeAnalysisContext context)
+    /// <param name="onMethod"></param>
+    static void EnsureMutationDoesNotAccessCurrentTime(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax onMethod)
     {
         var currentTimeInvocations = onMethod.DescendantNodes()
             .OfType<MemberAccessExpressionSyntax>()
@@ -144,7 +144,6 @@ public class AggregateAnalyzer : DiagnosticAnalyzer
                 new[] { currentTimeInvocation.ToFullString() }
             ));
         }
-        
     }
 
     static void CheckAggregateRootAttributePresent(SyntaxNodeAnalysisContext context, INamedTypeSymbol aggregateClass)

--- a/Source/Analyzers/Analyzers.csproj
+++ b/Source/Analyzers/Analyzers.csproj
@@ -12,7 +12,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Analyzers/CodeFixes/AttributeIdentityCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/AttributeIdentityCodeFixProvider.cs
@@ -21,7 +21,7 @@ public class AttributeIdentityCodeFixProvider : CodeFixProvider
 {
     /// <inheritdoc />
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(DiagnosticIds.AttributeInvalidIdentityRuleId);
-
+    
     /// <inheritdoc />
     public override Task RegisterCodeFixesAsync(CodeFixContext context)
     {
@@ -31,7 +31,6 @@ public class AttributeIdentityCodeFixProvider : CodeFixProvider
         {
             return Task.CompletedTask;
         }
-
         switch (diagnostic.Id)
         {
             case DiagnosticIds.AttributeInvalidIdentityRuleId:

--- a/Source/Analyzers/CodeFixes/AttributeMissingCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/AttributeMissingCodeFixProvider.cs
@@ -25,7 +25,7 @@ public class AttributeMissingCodeFixProvider : CodeFixProvider
             DiagnosticIds.AggregateMissingAttributeRuleId,
             DiagnosticIds.EventMissingAttributeRuleId,
             DiagnosticIds.ProjectionMissingAttributeRuleId);
-
+    
     /// <inheritdoc />
     public override Task RegisterCodeFixesAsync(CodeFixContext context)
     {

--- a/Source/Analyzers/CodeFixes/CodeFixExtensions.cs
+++ b/Source/Analyzers/CodeFixes/CodeFixExtensions.cs
@@ -13,19 +13,24 @@ static class Extensions
 {
     static readonly LineEndingsRewriter _lineEndingsRewriter = new();
 
-    public static T WithLfLineEndings<T>(this T replacedNode) where T : SyntaxNode => (T)_lineEndingsRewriter.Visit(replacedNode);
+    public static T WithLfLineEndings<T>(this T replacedNode) where T : SyntaxNode =>
+        (T)_lineEndingsRewriter.Visit(replacedNode);
 
-    public static CompilationUnitSyntax AddMissingUsingDirectives(this CompilationUnitSyntax root, params INamespaceSymbol[] namespaces)
+    public static CompilationUnitSyntax AddMissingUsingDirectives(this CompilationUnitSyntax root,
+        params INamespaceSymbol[] namespaces)
     {
-        return root.AddMissingUsingDirectives(namespaces.Select(_ => _.ToDisplayString()).ToArray());
+        return root.AddMissingUsingDirectives(namespaces.Select(it => it.ToDisplayString()).ToArray());
     }
-    public static CompilationUnitSyntax AddMissingUsingDirectives(this CompilationUnitSyntax root, params string[] namespaces)
+
+    public static CompilationUnitSyntax AddMissingUsingDirectives(this CompilationUnitSyntax root,
+        params string[] namespaces)
     {
         var usingDirectives = root.DescendantNodes().OfType<UsingDirectiveSyntax>().ToList();
         var nonImportedNamespaces = namespaces.ToImmutableHashSet();
 
         foreach (var usingDirective in usingDirectives)
         {
+            if (usingDirective.Name is null) continue;
             var usingDirectiveName = usingDirective.Name.ToString();
             if (nonImportedNamespaces.Contains(usingDirectiveName))
             {
@@ -35,8 +40,9 @@ static class Extensions
 
         if (!nonImportedNamespaces.Any()) return root;
 
-        var newUsingDirectives = nonImportedNamespaces.Select(namespaceName => SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))).ToArray();
-        
+        var newUsingDirectives = nonImportedNamespaces
+            .Select(namespaceName => SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))).ToArray();
+
         return root.AddUsings(newUsingDirectives).NormalizeWhitespace();
     }
 }

--- a/Source/Analyzers/CodeFixes/EventHandlerEventContextCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/EventHandlerEventContextCodeFixProvider.cs
@@ -14,13 +14,21 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Dolittle.SDK.Analyzers.CodeFixes;
 
+/// <summary>
+/// Code fix provider for adding EventContext parameter to event handler methods
+/// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AttributeMissingCodeFixProvider)), Shared]
 public class EventHandlerEventContextCodeFixProvider : CodeFixProvider
 {
+    /// <inheritdoc />
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
         DiagnosticIds.EventHandlerMissingEventContext
     );
 
+    /// inheritdoc
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    
+    /// inheritdoc
     public override Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var document = context.Document;
@@ -44,7 +52,7 @@ public class EventHandlerEventContextCodeFixProvider : CodeFixProvider
         return Task.CompletedTask;
     }
 
-    async Task<Document> AddEventContextParameter(CodeFixContext context, Diagnostic diagnostic, Document document, CancellationToken ct)
+    async Task<Document> AddEventContextParameter(CodeFixContext context, Diagnostic diagnostic, Document document, CancellationToken _)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         if (root is null) return document;
@@ -67,7 +75,7 @@ public class EventHandlerEventContextCodeFixProvider : CodeFixProvider
     /// </summary>
     /// <param name="methodDeclaration"></param>
     /// <returns></returns>
-    MethodDeclarationSyntax WithEventContextParameter(MethodDeclarationSyntax methodDeclaration)
+    static MethodDeclarationSyntax WithEventContextParameter(MethodDeclarationSyntax methodDeclaration)
     {
         var existingParameters = methodDeclaration.ParameterList.Parameters;
         // Get the first parameter that is not the EventContext parameter
@@ -101,7 +109,7 @@ public class EventHandlerEventContextCodeFixProvider : CodeFixProvider
         return methodDeclaration;
     }
 
-    public static CompilationUnitSyntax EnsureNamespaceImported(CompilationUnitSyntax root, string namespaceToInclude)
+    static CompilationUnitSyntax EnsureNamespaceImported(CompilationUnitSyntax root, string namespaceToInclude)
     {
         var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceToInclude));
         var existingUsings = root.Usings;
@@ -111,7 +119,7 @@ public class EventHandlerEventContextCodeFixProvider : CodeFixProvider
             // Namespace is already imported.
             return root;
         }
-        var lineEndingTrivia = root.DescendantTrivia().First(_ => _.IsKind(SyntaxKind.EndOfLineTrivia));
+        var lineEndingTrivia = root.DescendantTrivia().First(it => it.IsKind(SyntaxKind.EndOfLineTrivia));
         usingDirective = usingDirective.WithTrailingTrivia(lineEndingTrivia);
 
         return root.WithUsings(existingUsings.Add(usingDirective));

--- a/Source/Analyzers/CodeFixes/EventHandlerEventContextCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/EventHandlerEventContextCodeFixProvider.cs
@@ -17,7 +17,7 @@ namespace Dolittle.SDK.Analyzers.CodeFixes;
 /// <summary>
 /// Code fix provider for adding EventContext parameter to event handler methods
 /// </summary>
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AttributeMissingCodeFixProvider)), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(EventHandlerEventContextCodeFixProvider)), Shared]
 public class EventHandlerEventContextCodeFixProvider : CodeFixProvider
 {
     /// <inheritdoc />

--- a/Source/Analyzers/CodeFixes/MissingBaseClassCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/MissingBaseClassCodeFixProvider.cs
@@ -16,7 +16,7 @@ namespace Dolittle.SDK.Analyzers.CodeFixes;
 /// <summary>
 /// Codefix provider for adding missing base classes according to the diagnostic
 /// </summary>
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MethodVisibilityCodeFixProvider))]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MissingBaseClassCodeFixProvider))]
 public class MissingBaseClassCodeFixProvider : CodeFixProvider
 {
     /// <inheritdoc />

--- a/Source/Analyzers/CodeFixes/MissingBaseClassCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/MissingBaseClassCodeFixProvider.cs
@@ -13,11 +13,19 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Dolittle.SDK.Analyzers.CodeFixes;
 
+/// <summary>
+/// Codefix provider for adding missing base classes according to the diagnostic
+/// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MethodVisibilityCodeFixProvider))]
 public class MissingBaseClassCodeFixProvider : CodeFixProvider
 {
+    /// <inheritdoc />
     public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(DiagnosticIds.MissingBaseClassRuleId);
 
+    /// <inheritdoc />
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc />
     public override Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var diagnostic = context.Diagnostics.First();
@@ -40,7 +48,7 @@ public class MissingBaseClassCodeFixProvider : CodeFixProvider
 
    
     
-    async Task<Document> AddBaseClassAsync(Document document, Diagnostic diagnostic, string missingClass, CancellationToken cancellationToken)
+    static async Task<Document> AddBaseClassAsync(Document document, Diagnostic diagnostic, string missingClass, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
@@ -56,7 +64,7 @@ public class MissingBaseClassCodeFixProvider : CodeFixProvider
         var newClassDeclaration = classDeclaration.AddBaseListTypes(SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName(baseClassType.Name))).NormalizeWhitespace();
     
         // Add using directive for the namespace if it's not already there
-        var namespaceToAdd = baseClassType?.ContainingNamespace?.ToDisplayString();
+        var namespaceToAdd = baseClassType.ContainingNamespace?.ToDisplayString();
         if (!string.IsNullOrEmpty(namespaceToAdd) && root is CompilationUnitSyntax compilationUnitSyntax &&
             !NamespaceImported(compilationUnitSyntax, namespaceToAdd!))
         {
@@ -72,7 +80,7 @@ public class MissingBaseClassCodeFixProvider : CodeFixProvider
 
 
 
-    bool NamespaceImported(CompilationUnitSyntax root, string namespaceName)
+    static bool NamespaceImported(CompilationUnitSyntax root, string namespaceName)
     {
         return root.Usings.Any(usingDirective => usingDirective.Name?.ToString() == namespaceName);
     }

--- a/Source/Analyzers/CodeFixes/ProjectionMutationEventTimeCodeFixProvider.cs
+++ b/Source/Analyzers/CodeFixes/ProjectionMutationEventTimeCodeFixProvider.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Dolittle.SDK.Analyzers.CodeFixes;
+
+/// <summary>
+/// Code fix provider for adding EventContext parameter to event handler methods
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ProjectionMutationEventTimeCodeFixProvider)), Shared]
+public class ProjectionMutationEventTimeCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc />
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+        DiagnosticIds.ProjectionMutationUsedCurrentTime
+    );
+
+    /// inheritdoc
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// inheritdoc
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var document = context.Document;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            switch (diagnostic.Id)
+            {
+                case DiagnosticIds.ProjectionMutationUsedCurrentTime:
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            "Replace with EventContext.Occurred",
+                            ct => ReplaceDateTimeNowWithEventContextOccurred(context, diagnostic, document, ct),
+                            nameof(ProjectionMutationEventTimeCodeFixProvider) + ".UseEventContext"),
+                        diagnostic);
+                    break;
+            }
+        }
+
+
+        return Task.CompletedTask;
+    }
+
+    async Task<Document> ReplaceDateTimeNowWithEventContextOccurred(CodeFixContext context, Diagnostic diagnostic,
+        Document document, CancellationToken _)
+    {
+        if (!diagnostic.Properties.TryGetValue("expression", out var expression))
+        {
+            return document;
+        }
+
+        // Keep the type / kind of the expression
+        var replacement = expression switch
+        {
+            "System.DateTime.Now" => "Occurred.DateTime",
+            "System.DateTime.UtcNow" => "Occurred.UtcDateTime",
+            "System.DateTimeOffset.Now" => "Occurred",
+            "System.DateTimeOffset.UtcNow" => "Occurred",
+            _ => null
+        };
+
+        if (replacement is null)
+        {
+            return document;
+        }
+
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return document;
+
+        var existingMethod = GetMethodDeclaration(root, diagnostic);
+        if (existingMethod is null) return document;
+        var dateTimeNode = root.FindNode(diagnostic.Location.SourceSpan);
+
+        var (parameterList, eventContextParameterName) = GetParameterListAndContextName(existingMethod.ParameterList);
+
+
+        root = root.ReplaceNodes(new[] { existingMethod.ParameterList, dateTimeNode }, (original, _) =>
+        {
+            if (original == existingMethod.ParameterList)
+            {
+                return parameterList;
+            }
+
+            return SyntaxFactory.ParseExpression(eventContextParameterName + "." + replacement);
+        });
+
+
+        root = EnsureNamespaceImported((CompilationUnitSyntax)root, "Dolittle.SDK.Events");
+
+        return document.WithSyntaxRoot(root.NormalizeWhitespace(eol:"\n"));
+    }
+
+    static (ParameterListSyntax, string eventContextParameterName) GetParameterListAndContextName(
+        ParameterListSyntax parameterList)
+    {
+        if (parameterList.Parameters.Count < 2) // Missing EventContext parameter
+        {
+            // Add the EventContext parameter
+            return (WithEventContextParameter(parameterList), "ctx");
+        }
+
+        // Get the parameter name
+        var parameterName = parameterList.Parameters[1].Identifier.Text;
+        return (parameterList, parameterName);
+    }
+
+    static ParameterListSyntax WithEventContextParameter(ParameterListSyntax parameterList, string parameterName = "ctx")
+    {
+        var existingParameters = parameterList.Parameters;
+        // Get the first parameter that is not the EventContext parameter
+        var eventParameter = existingParameters.FirstOrDefault(parameter => parameter.Type?.ToString() != "EventContext");
+        if (eventParameter is null)
+        {
+            return parameterList;
+        }
+
+        var eventContextParameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier(parameterName))
+            .WithType(SyntaxFactory.ParseTypeName("EventContext"));
+
+        return parameterList.WithParameters(parameterList.Parameters.Insert(1, eventContextParameter));
+    }
+
+    MethodDeclarationSyntax? GetMethodDeclaration(SyntaxNode root, Diagnostic diagnostic)
+    {
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+        var methodDeclaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf()
+            .OfType<MethodDeclarationSyntax>().First();
+        return methodDeclaration;
+    }
+
+    static CompilationUnitSyntax EnsureNamespaceImported(CompilationUnitSyntax root, string namespaceToInclude)
+    {
+        var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceToInclude));
+        var existingUsings = root.Usings;
+
+        if (existingUsings.Any(u => u.Name?.ToFullString() == namespaceToInclude))
+        {
+            // Namespace is already imported.
+            return root;
+        }
+
+        var lineEndingTrivia = root.DescendantTrivia().First(it => it.IsKind(SyntaxKind.EndOfLineTrivia));
+        usingDirective = usingDirective.WithTrailingTrivia(lineEndingTrivia);
+
+        return root.WithUsings(existingUsings.Add(usingDirective));
+    }
+}

--- a/Source/Analyzers/DescriptorRules.cs
+++ b/Source/Analyzers/DescriptorRules.cs
@@ -234,6 +234,16 @@ static class DescriptorRules
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
                 description: "The event type is already handled by another On-method.");
+        
+        internal static readonly DiagnosticDescriptor MutationsCannotUseCurrentTime =
+            new(
+                DiagnosticIds.ProjectionMutationsCannotUseCurrentTime,
+                title: "On-methods must only use data from the event or EventContext",
+                messageFormat: "'{0}' is invalid, On-methods must only use data from the event or EventContext",
+                DiagnosticCategories.Sdk,
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                description: "If you need to get the committed time of the event, use EventContext.Occurred.");
     }
 
 }

--- a/Source/Analyzers/DescriptorRules.cs
+++ b/Source/Analyzers/DescriptorRules.cs
@@ -140,7 +140,17 @@ static class DescriptorRules
                 DiagnosticCategories.Sdk,
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
-                description: "Change the On-method to take a single event as a parameter");
+                description: "Change the On-method to take a single event as a parameter.");
+        
+        internal static readonly DiagnosticDescriptor MutationsCannotUseCurrentTime =
+            new(
+                DiagnosticIds.AggregateMutationsCannotUseCurrentTime,
+                title: "On-methods must only use data from the event",
+                messageFormat: "'{0}' is invalid, On-methods must only use data from the event",
+                DiagnosticCategories.Sdk,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                description: "If you need to capture the time of the event in the aggregate state, you must include it in the event.");
 
         internal static readonly DiagnosticDescriptor MutationsCannotProduceEvents = new(
             DiagnosticIds.AggregateMutationsCannotProduceEvents,

--- a/Source/Analyzers/DescriptorRules.cs
+++ b/Source/Analyzers/DescriptorRules.cs
@@ -235,9 +235,9 @@ static class DescriptorRules
                 isEnabledByDefault: true,
                 description: "The event type is already handled by another On-method.");
         
-        internal static readonly DiagnosticDescriptor MutationsCannotUseCurrentTime =
+        internal static readonly DiagnosticDescriptor MutationUsedCurrentTime =
             new(
-                DiagnosticIds.ProjectionMutationsCannotUseCurrentTime,
+                DiagnosticIds.ProjectionMutationUsedCurrentTime,
                 title: "On-methods must only use data from the event or EventContext",
                 messageFormat: "'{0}' is invalid, On-methods must only use data from the event or EventContext",
                 DiagnosticCategories.Sdk,

--- a/Source/Analyzers/DiagnosticIds.cs
+++ b/Source/Analyzers/DiagnosticIds.cs
@@ -83,5 +83,5 @@ public static class DiagnosticIds
     public const string ProjectionInvalidOnMethodReturnTypeRuleId = "PROJ0004";
     public const string ProjectionInvalidOnMethodVisibilityRuleId = "PROJ0005";
     public const string ProjectionDuplicateEventHandler = "PROJ0006";
-    public const string ProjectionMutationsCannotUseCurrentTime = "PROJ0007";
+    public const string ProjectionMutationUsedCurrentTime = "PROJ0007";
 }

--- a/Source/Analyzers/DiagnosticIds.cs
+++ b/Source/Analyzers/DiagnosticIds.cs
@@ -83,4 +83,5 @@ public static class DiagnosticIds
     public const string ProjectionInvalidOnMethodReturnTypeRuleId = "PROJ0004";
     public const string ProjectionInvalidOnMethodVisibilityRuleId = "PROJ0005";
     public const string ProjectionDuplicateEventHandler = "PROJ0006";
+    public const string ProjectionMutationsCannotUseCurrentTime = "PROJ0007";
 }

--- a/Source/Analyzers/DiagnosticIds.cs
+++ b/Source/Analyzers/DiagnosticIds.cs
@@ -72,6 +72,10 @@ public static class DiagnosticIds
     /// </summary>
     public const string PublicMethodsCannotMutateAggregateState = "AGG0006";
 
+    /// <summary>
+    /// Current time can not be used in an On-method, use the timestamp from the event instead.
+    /// </summary>
+    public const string AggregateMutationsCannotUseCurrentTime = "AGG0007";
 
     public const string ProjectionMissingAttributeRuleId = "PROJ0001";
     public const string ProjectionMissingBaseClassRuleId = "PROJ0002";

--- a/Source/Analyzers/ProjectionsAnalyzer.cs
+++ b/Source/Analyzers/ProjectionsAnalyzer.cs
@@ -33,7 +33,8 @@ public class ProjectionsAnalyzer : DiagnosticAnalyzer
             DescriptorRules.Projection.InvalidOnMethodParameters,
             DescriptorRules.Projection.InvalidOnMethodReturnType,
             DescriptorRules.Projection.InvalidOnMethodVisibility,
-            DescriptorRules.Projection.EventTypeAlreadyHandled
+            DescriptorRules.Projection.EventTypeAlreadyHandled,
+            DescriptorRules.Projection.MutationsCannotUseCurrentTime
         );
 
     /// <inheritdoc />
@@ -61,7 +62,7 @@ public class ProjectionsAnalyzer : DiagnosticAnalyzer
     static void CheckOnMethods(SyntaxNodeAnalysisContext context, INamedTypeSymbol projectionType)
     {
         var members = projectionType.GetMembers();
-        var onMethods = members.Where(_ => _.Name.Equals("On")).OfType<IMethodSymbol>().ToArray();
+        var onMethods = members.Where(method => method.Name.Equals("On")).OfType<IMethodSymbol>().ToArray();
         var eventTypesHandled = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
 
         foreach (var onMethod in onMethods)
@@ -117,6 +118,7 @@ public class ProjectionsAnalyzer : DiagnosticAnalyzer
             }
             
             CheckOnReturnType(context, projectionType, onMethod, syntax);
+            EnsureMutationDoesNotAccessCurrentTime(context, syntax);
         }
     }
 
@@ -156,6 +158,42 @@ public class ProjectionsAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    /// <summary>
+    /// Checks if the method gets the current time via DateTime or DateTimeOffset
+    /// Since this is not allowed for the mutations, we need to report a diagnostic
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="onMethod"></param>
+    static void EnsureMutationDoesNotAccessCurrentTime(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax onMethod)
+    {
+        var currentTimeInvocations = onMethod.DescendantNodes()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Where(memberAccess =>
+            {
+                var now = memberAccess.Name
+                    is IdentifierNameSyntax { Identifier.Text: "Now" }
+                    or IdentifierNameSyntax { Identifier.Text: "UtcNow" };
+                if (!now)
+                {
+                    return false;
+                }
+                
+                var typeInfo = context.SemanticModel.GetTypeInfo(memberAccess.Expression);
+                // Check if the type is DateTime or DateTimeOffset
+                return typeInfo.Type?.ToDisplayString() == "System.DateTime" || typeInfo.Type?.ToDisplayString() == "System.DateTimeOffset";
+                
+            }).ToArray();
+
+        foreach (var currentTimeInvocation in currentTimeInvocations)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DescriptorRules.Projection.MutationsCannotUseCurrentTime,
+                currentTimeInvocation.GetLocation(),
+                new[] { currentTimeInvocation.ToFullString() }
+            ));
+        }
+    }
+    
     static void CheckProjectionAttributePresent(SyntaxNodeAnalysisContext context, INamedTypeSymbol projectionClass)
     {
         var hasAttribute = projectionClass.GetAttributes()

--- a/Source/Analyzers/RoslynExtensions.cs
+++ b/Source/Analyzers/RoslynExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Dolittle.SDK.Analyzers;
+
+static class RoslynExtensions
+{
+    public static MemberAccessExpressionSyntax[] GetAccessesOfCurrentTime(this SyntaxNode scope,
+        SyntaxNodeAnalysisContext context)
+    {
+        var currentTimeInvocations = scope.DescendantNodes()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Where(memberAccess =>
+            {
+                var now = memberAccess.Name
+                    is IdentifierNameSyntax { Identifier.Text: "Now" }
+                    or IdentifierNameSyntax { Identifier.Text: "UtcNow" };
+                if (!now)
+                {
+                    return false;
+                }
+
+                var typeInfo = context.SemanticModel.GetTypeInfo(memberAccess.Expression);
+                // Check if the type is DateTime or DateTimeOffset
+                return typeInfo.Type?.ToDisplayString() == "System.DateTime" ||
+                       typeInfo.Type?.ToDisplayString() == "System.DateTimeOffset";
+            }).ToArray();
+
+        return currentTimeInvocations;
+    }
+}

--- a/Tests/Analyzers/Analyzers.csproj
+++ b/Tests/Analyzers/Analyzers.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />

--- a/Tests/Analyzers/CodeFixes/ProjectionMutationEventTimeCodeFixProviderTests.cs
+++ b/Tests/Analyzers/CodeFixes/ProjectionMutationEventTimeCodeFixProviderTests.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Dolittle.SDK.Analyzers.CodeFixes;
+
+public class ProjectionMutationEventTimeCodeFixProviderTests : CodeFixProviderTests<ProjectionsAnalyzer, ProjectionMutationEventTimeCodeFixProvider>
+{
+    [Fact]
+    public async Task ShouldFixDateTimeNow()
+    {
+        var test = @"
+using System;
+using Dolittle.SDK.Projections;
+using Dolittle.SDK.Events;
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+public record NameUpdated(string Name);
+
+[Projection(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeProjection: ReadModel
+{
+    public string Name { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public void On(NameUpdated evt) {
+        Name = evt.Name;
+        UpdatedAt = DateTime.Now;
+    }
+}";
+
+        var expected = @"using System;
+using Dolittle.SDK.Projections;
+using Dolittle.SDK.Events;
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+public record NameUpdated(string Name);
+[Projection(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeProjection : ReadModel
+{
+    public string Name { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public void On(NameUpdated evt, EventContext ctx)
+    {
+        Name = evt.Name;
+        UpdatedAt = ctx.Occurred.DateTime;
+    }
+}";
+        var diagnosticResult = Diagnostic(DescriptorRules.Projection.MutationUsedCurrentTime)
+            .WithSpan(17, 21, 17, 33)
+            .WithArguments("DateTime.Now");
+
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+    
+    [Fact]
+    public async Task ShouldFixDateTimeOffsetNow()
+    {
+        var test = @"
+using System;
+using Dolittle.SDK.Projections;
+using Dolittle.SDK.Events;
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+public record NameUpdated(string Name);
+
+[Projection(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeProjection: ReadModel
+{
+    public string Name { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    public void On(NameUpdated evt) {
+        Name = evt.Name;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}";
+
+        var expected = @"using System;
+using Dolittle.SDK.Projections;
+using Dolittle.SDK.Events;
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+public record NameUpdated(string Name);
+[Projection(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeProjection : ReadModel
+{
+    public string Name { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    public void On(NameUpdated evt, EventContext ctx)
+    {
+        Name = evt.Name;
+        UpdatedAt = ctx.Occurred;
+    }
+}";
+        var diagnosticResult = Diagnostic(DescriptorRules.Projection.MutationUsedCurrentTime)
+            .WithSpan(17, 21, 17, 42)
+            .WithArguments("DateTimeOffset.UtcNow");
+
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+    
+    [Fact]
+    public async Task ShouldFixDateTimeOffsetNowWithPreExistingEventContext()
+    {
+        var test = @"
+using System;
+using Dolittle.SDK.Projections;
+using Dolittle.SDK.Events;
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+public record NameUpdated(string Name);
+
+[Projection(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeProjection: ReadModel
+{
+    public string Name { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    public void On(NameUpdated evt, EventContext context) {
+        Name = evt.Name;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+}";
+
+        var expected = @"using System;
+using Dolittle.SDK.Projections;
+using Dolittle.SDK.Events;
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+public record NameUpdated(string Name);
+[Projection(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeProjection : ReadModel
+{
+    public string Name { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    public void On(NameUpdated evt, EventContext context)
+    {
+        Name = evt.Name;
+        UpdatedAt = context.Occurred;
+    }
+}";
+        var diagnosticResult = Diagnostic(DescriptorRules.Projection.MutationUsedCurrentTime)
+            .WithSpan(17, 21, 17, 42)
+            .WithArguments("DateTimeOffset.UtcNow");
+
+        await VerifyCodeFixAsync(test, expected, diagnosticResult);
+    }
+}

--- a/Tests/Analyzers/Diagnostics/ProjectionAnalyzerTests.cs
+++ b/Tests/Analyzers/Diagnostics/ProjectionAnalyzerTests.cs
@@ -309,4 +309,73 @@ class SomeProjection: ReadModel
 
         await VerifyAnalyzerAsync(test, expected);
     }
+    
+    [Fact]
+    public async Task ShouldFindDateTimeNow()
+    {
+        var test = @"
+using System;
+using Dolittle.SDK.Projections;
+using Dolittle.SDK.Events;
+
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+record NameUpdated(string Name);
+
+[Projection(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeProjection: ReadModel
+{
+    public string Name {get; set;}
+    public DateTime LastUpdated {get; set;}
+
+    public void On(NameUpdated evt)
+    {
+        Name = evt.Name;
+        LastUpdated = DateTime.Now;
+    }
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.Projection.MutationsCannotUseCurrentTime)
+                .WithSpan(19, 23, 19, 35)
+                .WithArguments("DateTime.Now")
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFindDateTimeOffsetNow()
+    {
+        var test = @"
+using System;
+using Dolittle.SDK.Projections;
+using Dolittle.SDK.Events;
+
+
+[EventType(""5dc02e84-c6fc-4e1b-997c-ec33d0048a3b"")]
+record NameUpdated(string Name);
+
+[Projection(""10ef9f40-3e61-444a-9601-f521be2d547e"")]
+class SomeProjection: ReadModel
+{
+    public string Name {get; set;}
+    public DateTimeOffset LastUpdated {get; set;}
+
+    public void On(NameUpdated evt)
+    {
+        Name = evt.Name;
+        LastUpdated = DateTimeOffset.UtcNow;
+    }
+}";
+        DiagnosticResult[] expected =
+        {
+            Diagnostic(DescriptorRules.Projection.MutationsCannotUseCurrentTime)
+                .WithSpan(19, 23, 19, 44)
+                .WithArguments("DateTimeOffset.UtcNow")
+        };
+
+        await VerifyAnalyzerAsync(test, expected);
+    }
+    
 }

--- a/Tests/Analyzers/Diagnostics/ProjectionAnalyzerTests.cs
+++ b/Tests/Analyzers/Diagnostics/ProjectionAnalyzerTests.cs
@@ -336,7 +336,7 @@ class SomeProjection: ReadModel
 }";
         DiagnosticResult[] expected =
         {
-            Diagnostic(DescriptorRules.Projection.MutationsCannotUseCurrentTime)
+            Diagnostic(DescriptorRules.Projection.MutationUsedCurrentTime)
                 .WithSpan(19, 23, 19, 35)
                 .WithArguments("DateTime.Now")
         };
@@ -370,7 +370,7 @@ class SomeProjection: ReadModel
 }";
         DiagnosticResult[] expected =
         {
-            Diagnostic(DescriptorRules.Projection.MutationsCannotUseCurrentTime)
+            Diagnostic(DescriptorRules.Projection.MutationUsedCurrentTime)
                 .WithSpan(19, 23, 19, 44)
                 .WithArguments("DateTimeOffset.UtcNow")
         };

--- a/Tests/ProjectionsTests/Occurred/SalesPerDay.cs
+++ b/Tests/ProjectionsTests/Occurred/SalesPerDay.cs
@@ -32,7 +32,7 @@ public class SalesPerDayByStoreProperty : ReadModel
 [Projection("3dce944f-279e-4150-bef3-dd9e113220c6")]
 public class SalesPerDayTotalByEventSource : ReadModel
 {
-    public string Store { get; private set; }
+    public string Store { get; private set; } = null!;
     public DateOnly Date { get; private set; }
 
     public decimal TotalSales { get; private set; }
@@ -58,7 +58,7 @@ class ProductKeySelector: IKeySelector<ProductSold>
 [Projection("3dce944f-279e-4150-bef3-dd9e113220c6")]
 public class SalesPerDayTotalByFunction : ReadModel
 {
-    public string Store { get; private set; }
+    public string Store { get; private set; } = null!;
     public DateOnly Date { get; private set; }
 
     public decimal TotalSales { get; private set; }


### PR DESCRIPTION
## Summary

Updates analyzers to make sure current time is not being used to populate read models or hydrate aggregate state.
Using current time will cause the state to no longer be idempotent, and breaks the abstraction. This also adds a code fix to change the time provider to be the time when the event was committed.

### Added
- Analysis & Codefix for projections
- Analysis for aggregate roots.