### PR TITLE
Exception analyzers / test helpers

### DIFF
--- a/Source/Analyzers/DescriptorRules.cs
+++ b/Source/Analyzers/DescriptorRules.cs
@@ -77,6 +77,17 @@ static class DescriptorRules
             isEnabledByDefault: true,
             description: "Change the accessibility level to '{1}'.");
 
+
+    internal static readonly DiagnosticDescriptor ExceptionInMutation =
+        new(
+            DiagnosticIds.ExceptionInMutation,
+            title: "Exceptions can not be thrown from mutation methods",
+            messageFormat: "On-methods can not throw exceptions",
+            DiagnosticCategories.Sdk,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "On-methods can not throw exceptions. This will prevent the system from being able to replay events.");
+    
     internal static class Events
     {
         internal static readonly DiagnosticDescriptor MissingAttribute =

--- a/Source/Analyzers/DiagnosticIds.cs
+++ b/Source/Analyzers/DiagnosticIds.cs
@@ -35,11 +35,14 @@ public static class DiagnosticIds
     public const string EventHandlerMissingEventContext = "SDK0007";
 
     public const string MissingBaseClassRuleId = "SDK0008";
-    
+
     /// <summary>
     /// Invalid timespan.
     /// </summary>
     public const string InvalidTimeSpanParameter = "SDK0009";
+
+
+    public const string ExceptionInMutation = "SDK0010";
 
     /// <summary>
     /// Aggregate missing the required Attribute.

--- a/Source/Testing/Aggregates/AggregateRootTests.cs
+++ b/Source/Testing/Aggregates/AggregateRootTests.cs
@@ -16,7 +16,7 @@ public abstract class AggregateRootTests<T> where T : AggregateRoot
 {
     readonly EventSourceId _eventSourceId;
     readonly AggregateOfMock<T> _aggregateOf;
-    
+
     /// <summary>
     /// Gets the <see cref="AggregateRootAssertion"/> that allows for asserting on the aggregate root.
     /// </summary>
@@ -94,7 +94,7 @@ public abstract class AggregateRootTests<T> where T : AggregateRoot
             throw e.InnerException ?? e;
         }
     }
-    
+
     /// <summary>
     /// Verify that an exception is thrown when performing an action on the aggregate.
     /// </summary>
@@ -103,16 +103,32 @@ public abstract class AggregateRootTests<T> where T : AggregateRoot
     protected Exception VerifyThrows(Action<T> action) => VerifyThrowsExactly<Exception>(action);
 
     /// <summary>
+    /// Verify that an exception is thrown when performing an action
+    /// </summary>
+    /// <param name="action">Aggregate callback</param>
+    /// <exception cref="DolittleAssertionFailed">Thrown when expectation is not met.</exception>
+    protected Exception VerifyThrows(Action action) => VerifyThrowsExactly<Exception>(action);
+
+    /// <summary>
     /// Verify that an exception of the specific type is thrown when performing an action on the aggregate.
     /// </summary>
     /// <param name="action">Aggregate callback</param>
     /// <typeparam name="TException">The expected Exception type to be thrown</typeparam>
     /// <exception cref="DolittleAssertionFailed">Thrown when expectation is not met.</exception>
-    protected TException VerifyThrowsExactly<TException>(Action<T> action) where TException : Exception
+    protected TException VerifyThrowsExactly<TException>(Action<T> action) where TException : Exception =>
+        VerifyThrowsExactly<TException>(() => WhenPerforming(action));
+
+    /// <summary>
+    /// Verify that an exception of the specific type is thrown when performing an action
+    /// </summary>
+    /// <param name="action">Aggregate callback</param>
+    /// <typeparam name="TException">The expected Exception type to be thrown</typeparam>
+    /// <exception cref="DolittleAssertionFailed">Thrown when expectation is not met.</exception>
+    protected TException VerifyThrowsExactly<TException>(Action action) where TException : Exception
     {
         try
         {
-            WhenPerforming(action);
+            action();
             throw new DolittleAssertionFailed(
                 $"Expected exception of type {typeof(TException).Name} but no exception was thrown");
         }
@@ -127,7 +143,5 @@ public abstract class AggregateRootTests<T> where T : AggregateRoot
             throw new DolittleAssertionFailed(
                 $"Expected exception of type {typeof(TException).Name} but got {e.GetType().Name}");
         }
-        
-        
     }
 }


### PR DESCRIPTION
## Summary

This patch adds analyzers to verify that mutations do not throw exceptions. In addition it adds a few new helper methods to aggregate test classes

### Added
- Diagnostic: `ExceptionInMutation`
- AggregateRootTests exception helpers