### PR TITLE
Projection DI

### DIFF
--- a/Source/Projections/IRequireDependencies.cs
+++ b/Source/Projections/IRequireDependencies.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dolittle.SDK.Projections;
+
+/// <summary>
+/// Marks a read model that requires external dependencies
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public interface IRequireDependencies<T> where T : ReadModel
+{
+    /// <summary>
+    /// Initialize the read model with the required dependencies
+    /// </summary>
+    /// <param name="serviceProvider"></param>
+    /// <returns></returns>
+    public void Resolve(IServiceProvider serviceProvider);
+}

--- a/Tests/ProjectionsTests/ProjectionWithDependencyTests.cs
+++ b/Tests/ProjectionsTests/ProjectionWithDependencyTests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.SDK.Events;
+using Dolittle.SDK.Projections.Types;
+using Dolittle.SDK.Testing.Projections;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Dolittle.SDK.Projections;
+
+public class ProjectionWithDependencyTests : ProjectionTests<ReadModelWithDependency>
+{
+    static readonly List<NameChanged> _nameChangedEvents = new();
+
+    public ProjectionWithDependencyTests() : base(ConfigureServices)
+    {
+        _nameChangedEvents.Clear();
+    }
+
+    static void ConfigureServices(IServiceCollection services)
+    {
+        // This configures the TestDependency that is resolved by the projection DI
+        services.AddSingleton<TestDependency>(evt =>
+        {
+            _nameChangedEvents.Add(evt);
+        });
+    }
+
+    static readonly EventSourceId _eventSourceId = "foo";
+
+    [Fact]
+    public void ShouldUpdateProjectionOnAggregateChanges()
+    {
+        WhenAggregateMutated<TestAggregate>(_eventSourceId, agg => agg.Rename("Bob"));
+
+        AssertThat.HasReadModel(_eventSourceId.Value)
+            .AndThat(
+                it => it.Name.Should().Be("Bob"),
+                it => it.TimesChanged.Should().Be(1));
+        
+        _nameChangedEvents.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void ShouldUpdateProjectionOnAggregateChangesAgain()
+    {
+        WhenAggregateMutated<TestAggregate>(_eventSourceId, agg =>
+        {
+            agg.Rename("Bob");
+            agg.Rename("Bobby");
+        });
+
+        var projection = AssertThat.ReadModel(_eventSourceId.Value);
+        projection.Name.Should().Be("Bobby");
+        projection.TimesChanged.Should().Be(2);
+        _nameChangedEvents.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ShouldUpdateProjectionOnAggregateChangesAgainAndAgain()
+    {
+        WhenAggregateMutated<TestAggregate>(_eventSourceId, agg =>
+        {
+            agg.Rename("Bob");
+            agg.Rename("Bobby");
+        });
+
+        WhenAggregateMutated<TestAggregate>(_eventSourceId, agg =>
+        {
+            agg.Rename("Bobby");
+            agg.Rename("Bob");
+        });
+
+        var projection = AssertThat.ReadModel(_eventSourceId.Value);
+        projection.Name.Should().Be("Bob");
+        projection.TimesChanged.Should().Be(3);
+        _nameChangedEvents.Should().HaveCount(3);
+    }
+}

--- a/Tests/ProjectionsTests/Types/ReadModelWithDependency.cs
+++ b/Tests/ProjectionsTests/Types/ReadModelWithDependency.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dolittle.SDK.Projections.Types;
+
+public delegate void TestDependency(NameChanged evt);
+
+[Projection("bad319f1-6af8-48a0-b190-323e21ba6cde")]
+public class ReadModelWithDependency : ReadModel, IRequireDependencies<ReadModelWithDependency>
+{
+    TestDependency? _dep;
+
+    public string Name { get; set; } = string.Empty;
+    public int TimesChanged { get; set; }
+
+
+    public void Resolve(IServiceProvider serviceProvider) => _dep = serviceProvider.GetRequiredService<TestDependency>();
+
+    public void On(NameChanged evt)
+    {
+        Name = evt.Name;
+        TimesChanged++;
+        _dep?.Invoke(evt);
+    }
+}


### PR DESCRIPTION
## Summary

Allow projection read models to get dependencies from `IServiceProvider`  By extending `IRequireDependencies<T>`. It will then get a callback when initialized, and can resolve external dependencies scoped to its current tenant. This can enable logging use cases on init, mutations etc.

### Added
`Dolittle.SDK.Projections.IRequireDependencies<T>`, interface for read models to be able to inject dependencies
