### PR TITLE
ConceptAs<DateTimeOffset> fix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="ConsoleTables" Version="2.6.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.65.0" />
     <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
@@ -30,14 +30,14 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
     <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0" />
@@ -49,25 +49,25 @@
     <PackageVersion Include="Proto.Remote" Version="1.7.1-alpha.0.1" />
     <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.1-alpha.0.1" />
     <PackageVersion Include="Proto.Cluster" Version="1.7.1-alpha.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.29.2" />
+    <PackageVersion Include="Google.Protobuf" Version="3.29.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.1" />
+    <PackageVersion Include="System.Formats.Asn1" Version="9.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="System.Security.Claims" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.1" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/Source/Events.Handling/ProcessRange.cs
+++ b/Source/Events.Handling/ProcessRange.cs
@@ -36,11 +36,4 @@ public record ProcessRange
 
     /// <summary>Do not process events that were committed after this (Optional)</summary>
     public DateTimeOffset? StopAt { get; init; }
-
-    public void Deconstruct(out ProcessFrom Mode, out DateTimeOffset? StartFrom, out DateTimeOffset? StopAt)
-    {
-        Mode = this.Mode;
-        StartFrom = this.StartFrom;
-        StopAt = this.StopAt;
-    }
 }

--- a/Source/Resources/MongoDB/ConceptSerializer.cs
+++ b/Source/Resources/MongoDB/ConceptSerializer.cs
@@ -43,6 +43,7 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
         // It should be a Concept object
         if (bsonType == BsonType.Document)
         {
+            var bookmark = bsonReader.GetBookmark();
             bsonReader.ReadStartDocument();
             var keyName = bsonReader.ReadName(Utf8NameDecoder.Instance);
             if (keyName is "Value" or "value")
@@ -52,7 +53,8 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
             }
             else
             {
-                throw new FailedConceptSerialization("Expected a concept object, but no key named 'Value' or 'value' was found on the object");
+                bsonReader.ReturnToBookmark(bookmark);
+                value = BsonSerializer.Deserialize(bsonReader, valueType);
             }
         }
         else
@@ -73,6 +75,8 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
         }
     }
 
+
+    
     /// <inheritdoc/>
     public void Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value)
     {


### PR DESCRIPTION
## Summary
Fixed a MongoDB serialization regression with ConceptAs in combination with DateTimeOffset and the MongoDB 3.0 driver.

This version combines compatibility with older serialized documents, as well as MongoDB driver 3.0 and newer.

In addition, this release upgrades Microsoft extensions, OpenTelemetry & Protobuf dependencies to the latest version

### Fixed
- ConceptAs<DateTimeOffset> serialization